### PR TITLE
Clean up SQL syntax and execute calls

### DIFF
--- a/extracters/basic.py
+++ b/extracters/basic.py
@@ -45,8 +45,8 @@ def deep_copy(data):
 def get_actor_type(ulan, uuid_cache, default="Actor"):
 	if not ulan:
 		return "Actor"
-	s = 'SELECT type FROM actor_type WHERE ulan="%s"' % ulan
-	res = uuid_cache.execute(s)
+	s = 'SELECT type FROM actor_type WHERE ulan = :ulan'
+	res = uuid_cache.execute(s, ulan=ulan)
 	v = res.fetchone()
 	if v:
 		return v[0]
@@ -77,7 +77,7 @@ def get_aat_label(term, gpi=None):
 	if term in aat_label_cache:
 		return aat_label_cache[term]
 	else:
-		res = gpi.execute('SELECT aat_label FROM aat WHERE aat_id=%s' % (term,))
+		res = gpi.execute('SELECT aat_label FROM aat WHERE aat_id = :id', id=term)
 		l = res.fetchone()
 		if l:
 			aat_label_cache[term] = l[0]

--- a/knoedler.py
+++ b/knoedler.py
@@ -83,7 +83,11 @@ def add_sales(graph):
 
 def add_missing(graph):
 	graph.add_chain(
-		bonobo_sqlalchemy.Select('SELECT pi_record_no, object_id, inventory_event_id, sale_event_id, purchase_event_id FROM knoedler WHERE inventory_event_id NOT NULL', 
+		bonobo_sqlalchemy.Select('''
+			SELECT pi_record_no, object_id, inventory_event_id, sale_event_id, purchase_event_id
+			FROM knoedler
+			WHERE inventory_event_id NOT NULL
+			''', 
 			engine='gpi', limit=LIMIT, pack_size=PACK_SIZE),
 		Offset(offset=150),
 		find_raw,
@@ -116,18 +120,24 @@ def add_missing(graph):
 
 def add_pre_post(graph):
 	graph.add_chain(
-		bonobo_sqlalchemy.Select('SELECT pp.rowid, pp.previous_owner_uid, pp.object_id, p.person_ulan, p.person_label ' +\
-			' FROM knoedler_previous_owners as pp, gpi_people as p ' +\
-			' WHERE p.person_uid = pp.previous_owner_uid', engine='gpi', limit=LIMIT, pack_size=PACK_SIZE),
+		bonobo_sqlalchemy.Select('''
+			SELECT pp.rowid, pp.previous_owner_uid, pp.object_id, p.person_ulan, p.person_label
+			FROM knoedler_previous_owners AS pp
+				JOIN gpi_people as p ON (p.person_uid = pp.previous_owner_uid)
+			''', engine='gpi', limit=LIMIT, pack_size=PACK_SIZE),
 			AddFieldNames(key="prev_post_owners", field_names=all_names),
 			add_prev_prev
 	)
 	chain1 = graph.nodes[-1]
 
 	graph.add_chain(
-		bonobo_sqlalchemy.Select('SELECT pp.rowid, pp.post_owner_uid, pp.object_id, p.person_ulan, p.person_label ' +\
-			' FROM knoedler_post_owners as pp, gpi_people as p ' +\
-			' WHERE p.person_uid = pp.post_owner_uid', engine='gpi', limit=LIMIT, pack_size=PACK_SIZE),
+		bonobo_sqlalchemy.Select('''
+			SELECT pp.rowid, pp.post_owner_uid, pp.object_id, p.person_ulan, p.person_label
+			FROM
+				knoedler_post_owners AS pp
+				JOIN gpi_people as p ON (p.person_uid = pp.post_owner_uid)
+			''',
+			engine='gpi', limit=LIMIT, pack_size=PACK_SIZE),
 			AddFieldNames(key="prev_post_owners", field_names=all_names),
 	)
 	chain2 = graph.nodes[-1]
@@ -171,8 +181,15 @@ def add_objects(graph):
 
 def add_people(graph):
 	graph.add_chain(
-		bonobo_sqlalchemy.Select('SELECT DISTINCT peeps.* from gpi_people as peeps, gpi_people_names_references as ref, gpi_people_names as names ' + \
-			'WHERE peeps.person_uid = names.person_uid AND names.person_name_id = ref.person_name_id and ref.source_record_id like "KNO%"', \
+		bonobo_sqlalchemy.Select('''
+			SELECT DISTINCT peeps.*
+			FROM
+				gpi_people AS peeps
+				JOIN gpi_people_names AS names ON (peeps.person_uid = names.person_uid)
+				JOIN gpi_people_names_references AS ref ON (names.person_name_id = ref.person_name_id)
+			WHERE
+				ref.source_record_id LIKE "KNO%"
+			''',
 			engine='gpi', limit=LIMIT, pack_size=PACK_SIZE),
 		AddFieldNames(key="gpi_people", field_names=all_names),
 		AddArchesModel(model=arches_models['Person']),


### PR DESCRIPTION
In working my way through the pipeline code, I've cleaned up the SQL calls to:

* Use multi-line literals to improve visual coherence of query strings
* Use explicit SQL `JOIN` syntax to separate join conditions from extra filtering expressions
* Use value binding to avoid need for escaping and prevent vectors for SQL injection