### PR TITLE
Clean up use of `sys.path` and add settings file

### DIFF
--- a/knoedler.py
+++ b/knoedler.py
@@ -1,13 +1,9 @@
+#!/usr/bin/env python3
 
 import sys, os
 from sqlalchemy import create_engine
 import bonobo
 import bonobo_sqlalchemy
-
-if os.path.exists('/Users/rsanderson'):
-	sys.path.insert(0,'/Users/rsanderson/Development/getty/pipeline')
-else:
-	sys.path.insert(0,'/home/rsanderson/Development/provenance/pipeline')
 
 from extracters.basic import AddArchesModel, AddFieldNames, Serializer, deep_copy, Offset, add_uuid
 from extracters.knoedler_data import *

--- a/knoedler.py
+++ b/knoedler.py
@@ -22,7 +22,7 @@ def get_services():
 ### Pipeline
 
 if DEBUG:
-	LIMIT     = 10
+	LIMIT     = os.environ.get('GETTY_PIPELINE_LIMIT', 10)
 	PACK_SIZE = 10
 	SRLZ = Serializer(compact=False)
 	WRITER = FileWriter(directory=output_file_path)

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,30 @@
+
+import os
+
+arches_models = {
+	"Acquisition": "b5fdce59-2e41-11e9-b1c2-a4d18cec433a",
+	"Phase": "17871ac7-2e42-11e9-87b2-a4d18cec433a",
+	"Activity": "24c45975-3955-11e9-80f0-a4d18cec433a",
+	"ManMadeObject": "2486c17d-2e42-11e9-bd33-a4d18cec433a",
+	"VisualItem": "504dcf0a-2e42-11e9-b4e2-a4d18cec433a",
+	"Person": "0b47366e-2e42-11e9-9018-a4d18cec433a",
+	"LinguisticObject": "41a41e47-2e42-11e9-b5ee-a4d18cec433a"
+}
+
+data_path = os.environ.get('GETTY_PIPELINE_INPUT', '/data/input/provenance/knoedler')
+output_file_path = os.environ.get('GETTY_PIPELINE_OUTPUT', '/data2/output/provenance/knoedler')
+DEBUG = os.environ.get('GETTY_PIPELINE_DEBUG', False)
+SPAM = os.environ.get('GETTY_PIPELINE_VERBOSE', False)
+
+if os.path.exists('/Users/rsanderson'):
+	gpi_engine = 'sqlite:////Users/rsanderson/Development/getty/provenance/matt/gpi.sqlite'
+	uuid_cache_engine = 'sqlite:////Users/rsanderson/Development/getty/pipeline/uuid_cache.sqlite'
+	raw_engine = 'sqlite:////Users/rsanderson/Development/getty/pipeline/data/raw_gpi.sqlite'
+	output_file_path = 'output'
+	DEBUG = True
+	SPAM = False
+else:
+	gpi_engine = 'sqlite:///%s/gpi.sqlite' % (data_path,)
+	uuid_cache_engine = 'sqlite:///%s/uuid_cache.sqlite' % (data_path,)
+	raw_engine = 'sqlite:///%s/raw_gpi.sqlite' % (data_path,)
+


### PR DESCRIPTION
This should work for direct invocations (`./knoedler.py` and `python3 knoedler.py`) but not for indirect invocation (`bonobo run knoedler.py`). This is due to the [implicit addition to `sys.path`](https://docs.python.org/3/library/sys.html#sys.path) of "the directory containing the script that was used to invoke the Python interpreter." If invoked via `bonobo`, the implicit path is going to be something like `/usr/local/bin`, *not* the directory with the pipeline source code in it.

I've left in the hard-coded custom settings in the settings file, but also added the ability to override settings using environment variables:

* `GETTY_PIPELINE_INPUT_PATH`
* `GETTY_PIPELINE_OUTPUT_PATH`
* `GETTY_PIPELINE_LIMIT`
* `GETTY_PIPELINE_DEBUG`
* `GETTY_PIPELINE_VERBOSE`

Of particular note, `GETTY_PIPELINE_INPUT_PATH` is a combined path for all 3 sqlite files, which appears to be the default setup, but *not* how the custom settings were configured. This can be updated if we want to split that out.