### PR TITLE
AATA abstracts and authors

### DIFF
--- a/aata.py
+++ b/aata.py
@@ -184,6 +184,12 @@ class AATAPipeline:
 
 
 class AATAFilePipeline(AATAPipeline):
+	'''
+	AATA pipeline with serialization to files based on Arches model and resource UUID.
+	
+	If in `debug` mode, JSON serialization will use pretty-printing. Otherwise,
+	serialization will be compact.
+	'''
 	def __init__(self, input_path, files, output_path=None, models=None, limit=None, debug=False):
 		super().__init__(input_path, files, models=models, limit=limit, debug=debug)
 		if debug:

--- a/extracters/basic.py
+++ b/extracters/basic.py
@@ -97,7 +97,7 @@ def get_aat_label(term, aat=None):
 class Trace(Configurable):
 	name = Option()
 	diff = Option(default=False)
-	ordinals = Option(default=(1,))
+	ordinals = Option(default=(0,))
 	trace_counter = Service('trace_counter')
 
 	def __call__(self, thing: dict, trace_counter):

--- a/tests/test_aata_pipeline.py
+++ b/tests/test_aata_pipeline.py
@@ -147,7 +147,7 @@ class TestAATAPipelineOutput(unittest.TestCase):
 		self.assertEqual(len(output[lo_model]), 2)
 		self.assertEqual(len(output[orgs_model]), 3)
 		
-		people = [s for s in output[people_model].values()]
+		people = output[people_model].values()
 		people_creation_events = set()
 		for p in people:
 			for e in p.get('carried_out', []):
@@ -156,7 +156,7 @@ class TestAATAPipelineOutput(unittest.TestCase):
 		people_names = sorted(p.get('_label') for p in people)
 		self.assertEqual(people_names, ['Bremner, Ian', 'Meyers, Eric'])
 
-		organizations = [s for s in output[orgs_model].values()]
+		organizations = output[orgs_model].values()
 		org_names = {}
 		for o in organizations:
 			try:
@@ -172,7 +172,7 @@ class TestAATAPipelineOutput(unittest.TestCase):
 			'WGBH Educational Foundation //Boston (Massachusetts, United States)'
 		])
 		
-		lo = [s for s in output[lo_model].values()]
+		lo = output[lo_model].values()
 		article_types = {}
 		source_creation_events = set()
 		abstract_creation_events = set()

--- a/tests/test_aata_pipeline.py
+++ b/tests/test_aata_pipeline.py
@@ -7,19 +7,71 @@ import pprint
 from bonobo.config import Configurable, Option
 import aata
 
+def merge_lists(l, r):
+	identified = {}
+	all = l + r
+	other = []
+	for item in all:
+		try:
+			id = i.get('id')
+			if id in identified:
+				identified[id] += [item]
+			else:
+				identified[id] = [item]
+		except:
+			other.append(item)
+
+	for items in identified:
+		yield merge(*items)
+	
+	yield from other
+
+def merge(l, r):
+	if l is None:
+		return r
+	if r is None:
+		return l
+
+	if type(l) != type(r):
+		pprint.pprint(l)
+		pprint.pprint(r)
+		raise Exception('bad data in json merge')
+	
+	if type(l) == dict:
+		keys = set(list(l.keys()) + list(r.keys()))
+		return {k: merge(l.get(k), r.get(k)) for k in keys}
+	elif type(l) == list:
+		return list(merge_lists(l, r))
+	elif type(l) == str:
+		if l == r:
+			return l
+		else:
+			raise Exception('data conflict: %r <=> %r' % (l, r))
+	else:
+		raise Exception('unhandled type: %r' % (type(l)))
+	return l
+
 class TestWriter(Configurable):
 	def __init__(self):
 		self.output = {}
+		self.parts = {}
 
 	def __call__(self, data: dict):
 		d = data['_OUTPUT']
 		dr = data['_ARCHES_MODEL']
 		if dr not in self.output:
 			self.output[dr] = {}
+			self.parts[dr] = {}
 		fn = '%s.json' % data['uuid']
+		data = json.loads(d)
 		if fn in self.output[dr]:
-			raise Exception('Output already exists for %r' % (fn,))
-		self.output[dr][fn] = d
+			existing = self.parts[dr][fn]
+			self.output[dr][fn] = merge(*existing, data)
+			self.parts[dr][fn].append(data)
+# 			raise Exception('Output already exists for %r' % (fn,))
+		else:
+			self.parts[dr][fn] = [data]
+			self.output[dr][fn] = data
 
 
 class AATATestPipeline(aata.AATAPipeline):
@@ -44,25 +96,32 @@ class TestAATAPipelineOutput(unittest.TestCase):
 		output = writer.output
 		self.assertEqual(len(output), 3)
 
-		articles_model = '41a41e47-2e42-11e9-b5ee-a4d18cec433a'
+		lo_model = '41a41e47-2e42-11e9-b5ee-a4d18cec433a'
 		people_model = '0b47366e-2e42-11e9-9018-a4d18cec433a'
 		orgs_model = 'XXX-Organization-Model'
 
 		expected_models = {
 			people_model,
-			articles_model,
+			lo_model,
 			orgs_model
 		}
+
+# 		pprint.pprint(output[people_model])
 		self.assertEqual(set(output.keys()), expected_models)
 		self.assertEqual(len(output[people_model]), 2)
-		self.assertEqual(len(output[articles_model]), 3)
+		self.assertEqual(len(output[lo_model]), 2)
 		self.assertEqual(len(output[orgs_model]), 3)
 		
-		people = [json.loads(s) for s in output[people_model].values()]
+		people = [s for s in output[people_model].values()]
+		people_creation_events = set()
+		for p in people:
+			for e in p.get('carried_out', []):
+				cid = e['id']
+				people_creation_events.add(cid)
 		people_names = sorted(p.get('_label') for p in people)
 		self.assertEqual(people_names, ['Bremner, Ian', 'Meyers, Eric'])
 
-		organizations = [json.loads(s) for s in output[orgs_model].values()]
+		organizations = [s for s in output[orgs_model].values()]
 		org_names = {}
 		for o in organizations:
 			try:
@@ -78,17 +137,37 @@ class TestAATAPipelineOutput(unittest.TestCase):
 			'WGBH Educational Foundation //Boston (Massachusetts, United States)'
 		])
 		
-		articles = [json.loads(s) for s in output[articles_model].values()]
+		lo = [s for s in output[lo_model].values()]
 		article_types = {}
-		for a in articles:
+		source_creation_events = set()
+		abstract_creation_events = set()
+		for a in lo:
+			i = a['id']
 			try:
-				i = a['id']
-				cl = a.get('classified_as')
-				c = cl[0]
-				l = c.get('_label')
-				article_types[i] = l
+				article_types[i] = a['classified_as'][0]['_label']
 			except Exception as e:
-				print('*** %s' % (e,))
+				print('*** error while handling linguistic object classification: %s' % (e,))
 				article_types[i] = None
+			try:
+				if 'created_by' in a:
+					if a['classified_as'][0]['_label'] == 'Abstract':
+						c = a['created_by']
+						cid = c['id']
+						for p in c.get('part', []):
+							abstract_creation_events.add(p.get('id'))
+				for thing in a.get('refers_to', []):
+					if 'created_by' in thing:
+						event = thing['created_by']
+						for p in event.get('part', []):
+							source_creation_events.add(p.get('id'))
+			except Exception as e:
+				print('*** error while handling creation event: %s' % (e,))
+				pprint.pprint(c)
+				source_creation_events[i] = None
 		types = sorted(article_types.values())
 		self.assertEqual(types, ['A/V Content', 'Abstract'])
+
+		# the creation sub-events from both the abstract and the
+		# thing-being-abstracted are carried out by the people
+		self.assertLessEqual(source_creation_events, people_creation_events)
+		self.assertLessEqual(abstract_creation_events, people_creation_events)

--- a/tests/test_aata_pipeline.py
+++ b/tests/test_aata_pipeline.py
@@ -54,23 +54,17 @@ def merge(l, r):
 class TestWriter(Configurable):
 	def __init__(self):
 		self.output = {}
-		self.parts = {}
 
 	def __call__(self, data: dict):
 		d = data['_OUTPUT']
 		dr = data['_ARCHES_MODEL']
 		if dr not in self.output:
 			self.output[dr] = {}
-			self.parts[dr] = {}
 		fn = '%s.json' % data['uuid']
 		data = json.loads(d)
 		if fn in self.output[dr]:
-			existing = self.parts[dr][fn]
-			self.output[dr][fn] = merge(*existing, data)
-			self.parts[dr][fn].append(data)
-# 			raise Exception('Output already exists for %r' % (fn,))
+			self.output[dr][fn] = merge(self.output[dr][fn], data)
 		else:
-			self.parts[dr][fn] = [data]
 			self.output[dr][fn] = data
 
 


### PR DESCRIPTION
This moves the handling of abstracts earlier in the bonobo graph so that abstracts depend just on the "articles" chain (the XML `/record`s). This fixes a problem that existed in cases where an article had an abstract but no authors. Authors are now re-converted to linkedart objects when/if they are needed to assert authorship of the abstract.

This PR also takes a stab at what should happen when JSON-LD data is serialized for the same resource in multiple places (different branches of the bonobo graph). The [`merge` function](https://github.com/thegetty/pipeline/compare/aata?expand=1#diff-d9aadae1544ad832fe7b9516463d1fb8R36) takes two json-like python structures and attempts to merge them sensibly (respecting things like `id` keys). If this approach works out, we'll probably need to improve this code and then have the pipeline fully materialize the output and merge data on-the-fly (with appropriate locking) before finally uploading to arches.