### PR TITLE
Date Formats

### DIFF
--- a/extracters/cleaners.py
+++ b/extracters/cleaners.py
@@ -107,7 +107,8 @@ def date_parse(value, delim):
 			d = m
 			m = tmp
 		try:
-			return [datetime(y,m,d), datetime(y,m,d)]
+			yearmonthday = datetime(y,m,d)
+			return [yearmonthday, yearmonthday+timedelta(days=1)]
 		except:
 			print("Bad // value: %s" % value)
 	else:

--- a/extracters/cleaners.py
+++ b/extracters/cleaners.py
@@ -1,7 +1,9 @@
-
+import locale
 import re
 from datetime import datetime, timedelta
+from dateutil.parser import parse
 import calendar
+from contextlib import contextmanager, suppress
 
 CIRCA = 5 # years
 CIRCA_D = timedelta(days=365*CIRCA)
@@ -128,6 +130,9 @@ def date_cleaner(value):
 	# YYYY/(Y|YY|YYYY)
 	# YYYY-YY
 	# YYY0s
+	# YYYY-
+	# YYYY Mon
+	# YYYY Month DD
 
 	if value:
 		value = value.replace("?",'')
@@ -142,9 +147,11 @@ def date_cleaner(value):
 
 	if not value:
 		return value
+
 	elif value.startswith("|"):
 		# Broken? null it out
 		return None
+
 	elif len(value) == 4 and value.isdigit():
 		# year only
 		return [datetime(int(value),1,1), datetime(int(value)+1,1,1)]
@@ -160,6 +167,11 @@ def date_cleaner(value):
 			return [datetime(y,1,1), datetime(y+10,1,1)]
 		else:
 			print("Bad YYYYs date: %s" % value)
+
+	elif len(value) == 5 and value[:4].isdigit() and value.endswith('-'):
+		y = int(value[:4])
+		return [datetime(y,1,1), None]
+
 	elif value.startswith("ca"):
 		# circa x
 		value = value[3:].strip()
@@ -179,6 +191,7 @@ def date_cleaner(value):
 			val[0] -= CIRCA_D
 			val[1] += CIRCA_D
 			return val
+
 	elif value.startswith('aft'):
 		# after x
 		value = value.replace('aft.', '')
@@ -190,30 +203,57 @@ def date_cleaner(value):
 			print("Bad aft value: %s" % value)
 			return None
 		return [datetime(y,1,1), None]
+
 	elif value.startswith('bef'):
 		value = value.replace('bef.', '')
 		value = value.replace('before ', '')
 		value = value.strip()
 		y = int(value)
 		return [None, datetime(y,1,1)]
+
 	elif value.find('/') > -1:
 		# year/year or year/month/date
 		# 1885/90
 		# 07/02/1897
 		return date_parse(value, '/')
+
 	elif value.find('.') > -1:
 		return date_parse(value, '.')
+
 	elif value.find('-') > -1:
 		return date_parse(value, '-')
+
 	elif value.find(';') > -1:
 		return date_parse(value, ';')
 
 	else:
+		with c_locale(), suppress(ValueError):
+			yearmonthday = datetime.strptime(value, '%Y %B %d')
+			if yearmonthday:
+				return [yearmonthday, yearmonthday]
+		
+		with c_locale(), suppress(ValueError):
+			yearmonth = datetime.strptime(value, '%Y %b')
+			if yearmonth:
+				year = yearmonth.year
+				month = yearmonth.month
+				maxday = calendar.monthrange(year, month)[1]
+				r = [datetime(year, month, 1), datetime(year, month, maxday)]
+				return r
+
 		print("fell through to: %s" % value)
 		return value
 
 
-
+@contextmanager
+def c_locale():
+	l = locale.getlocale()
+	locale.setlocale(locale.LC_ALL, 'C')
+	try:
+		yield
+	finally:
+		locale.setlocale(locale.LC_ALL, l)
+	
 def test_date_cleaner():
 	import sqlite3
 	c = sqlite3.connect('/Users/rsanderson/Development/getty/provenance/matt/gpi.sqlite')

--- a/extracters/cleaners.py
+++ b/extracters/cleaners.py
@@ -230,7 +230,7 @@ def date_cleaner(value):
 		with c_locale(), suppress(ValueError):
 			yearmonthday = datetime.strptime(value, '%Y %B %d')
 			if yearmonthday:
-				return [yearmonthday, yearmonthday]
+				return [yearmonthday, yearmonthday+timedelta(days=1)]
 		
 		with c_locale(), suppress(ValueError):
 			yearmonth = datetime.strptime(value, '%Y %b')
@@ -238,7 +238,8 @@ def date_cleaner(value):
 				year = yearmonth.year
 				month = yearmonth.month
 				maxday = calendar.monthrange(year, month)[1]
-				r = [datetime(year, month, 1), datetime(year, month, maxday)]
+				d = datetime(year, month, 1)
+				r = [d, d+timedelta(days=maxday)]
 				return r
 
 		print("fell through to: %s" % value)

--- a/extracters/cleaners.py
+++ b/extracters/cleaners.py
@@ -79,7 +79,7 @@ def date_parse(value, delim):
 		b1 = bits[0].strip()
 		b2 = bits[1].strip()
 		if len(b2) < 3 :
-			b2 = "%s%s" % (b1[:len(b2)], b2)
+			b2 = "%s%s" % (b1[:len(b1)-len(b2)], b2)
 		elif len(b2) > 4:
 			print("Bad range: %s" % value)
 			return None

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -22,7 +22,7 @@ class TestDateCleaners(unittest.TestCase):
 			'1802?': [datetime(1802,1,1), datetime(1803,1,1)],				# YYYY[?]
 			'1803/02/03': [datetime(1803,2,3), datetime(1803,2,4)],			# YYYY/MM/DD # TODO: currently failing, but the upper range should be the next day
 			'04/02/1804': [datetime(1804,2,4), datetime(1804,2,5)],			# DD/MM/YYYY # TODO: currently failing, but the upper range should be the next day
-			'ca. 1805': [datetime(1800,1,1), datetime(1810,1,1)],			# ca. YYYY
+			'ca. 1806': [datetime(1801,1,1), datetime(1811,1,1)],			# ca. YYYY
 			'aft. 1807': [datetime(1807,1,1), None],						# aft[er|.] YYYY
 			'after 1808': [datetime(1808,1,1), None],						# aft[er|.] YYYY
 			'bef. 1810': [None, datetime(1810,1,1)],						# bef[ore|.] YYYY

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,0 +1,45 @@
+import unittest 
+import sys
+import os
+import json
+import pprint
+from datetime import datetime
+import extracters.cleaners
+
+class TestDateCleaners(unittest.TestCase):
+	'''
+	Test the ability to recognize and parse various formats of dates.
+	'''
+	def setUp(self):
+		pass
+
+	def tearDown(self):
+		pass
+
+	def test_date_cleaner(self):
+		tests = {
+			'1801': [datetime(1801,1,1), datetime(1802,1,1)],				# YYYY[?]
+			'1802?': [datetime(1802,1,1), datetime(1803,1,1)],				# YYYY[?]
+			'1803/02/03': [datetime(1803,2,3), datetime(1803,2,4)],			# YYYY/MM/DD # TODO: currently failing, but the upper range should be the next day
+			'04/02/1804': [datetime(1804,2,4), datetime(1804,2,5)],			# DD/MM/YYYY # TODO: currently failing, but the upper range should be the next day
+			'ca. 1805': [datetime(1800,1,1), datetime(1810,1,1)],			# ca. YYYY
+			'aft. 1807': [datetime(1807,1,1), None],						# aft[er|.] YYYY
+			'after 1808': [datetime(1808,1,1), None],						# aft[er|.] YYYY
+			'bef. 1810': [None, datetime(1810,1,1)],						# bef[ore|.] YYYY
+			'before 1811': [None, datetime(1811,1,1)],						# bef[ore|.] YYYY
+			'1812.02.05': [datetime(1812,2,5), datetime(1812,2,6)],			# YYYY.MM.DD # TODO: currently failing, but the upper range should be the next day
+			'1813/4': [datetime(1813,1,1), datetime(1815,1,1)],				# YYYY/(Y|YY|YYYY)
+			'1814/21': [datetime(1814,1,1), datetime(1822,1,1)],			# YYYY/(Y|YY|YYYY)
+			'1815/1901': [datetime(1815,1,1), datetime(1902,1,1)],			# YYYY/(Y|YY|YYYY)
+			'1816-19': [datetime(1816,1,1), datetime(1820,1,1)],			# YYYY-YY
+			'1830s': [datetime(1830,1,1), datetime(1840,1,1)],				# YYY0s
+			'1841-': [datetime(1841,1,1), None],							# YYYY-
+			'1850 Mar': [datetime(1850,3,1), datetime(1850,4,1)],			# YYYY Mon
+			'1851 April 02': [datetime(1851,4,2), datetime(1851,4,3)],		# YYYY Month DD
+		}
+		
+		for value, expected in tests.items():
+			date_range = extracters.cleaners.date_cleaner(value)
+			self.assertIsInstance(date_range, list)
+			if expected is not None:
+				self.assertEqual(date_range, expected, msg=f'date string: {value!r}')

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,8 +1,4 @@
-import unittest 
-import sys
-import os
-import json
-import pprint
+import unittest
 from datetime import datetime
 import extracters.cleaners
 
@@ -17,6 +13,10 @@ class TestDateCleaners(unittest.TestCase):
 		pass
 
 	def test_date_cleaner(self):
+		'''
+		Test the documented formats that `extracters.cleaners.date_cleaner` can parse
+		and ensure that it returns the expected data.
+		'''
 		tests = {
 			'1801': [datetime(1801,1,1), datetime(1802,1,1)],				# YYYY[?]
 			'1802?': [datetime(1802,1,1), datetime(1803,1,1)],				# YYYY[?]

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -20,14 +20,14 @@ class TestDateCleaners(unittest.TestCase):
 		tests = {
 			'1801': [datetime(1801,1,1), datetime(1802,1,1)],				# YYYY[?]
 			'1802?': [datetime(1802,1,1), datetime(1803,1,1)],				# YYYY[?]
-			'1803/02/03': [datetime(1803,2,3), datetime(1803,2,4)],			# YYYY/MM/DD # TODO: currently failing, but the upper range should be the next day
-			'04/02/1804': [datetime(1804,2,4), datetime(1804,2,5)],			# DD/MM/YYYY # TODO: currently failing, but the upper range should be the next day
+			'1803/02/03': [datetime(1803,2,3), datetime(1803,2,4)],			# YYYY/MM/DD
+			'04/02/1804': [datetime(1804,2,4), datetime(1804,2,5)],			# DD/MM/YYYY
 			'ca. 1806': [datetime(1801,1,1), datetime(1811,1,1)],			# ca. YYYY
 			'aft. 1807': [datetime(1807,1,1), None],						# aft[er|.] YYYY
 			'after 1808': [datetime(1808,1,1), None],						# aft[er|.] YYYY
 			'bef. 1810': [None, datetime(1810,1,1)],						# bef[ore|.] YYYY
 			'before 1811': [None, datetime(1811,1,1)],						# bef[ore|.] YYYY
-			'1812.02.05': [datetime(1812,2,5), datetime(1812,2,6)],			# YYYY.MM.DD # TODO: currently failing, but the upper range should be the next day
+			'1812.02.05': [datetime(1812,2,5), datetime(1812,2,6)],			# YYYY.MM.DD
 			'1813/4': [datetime(1813,1,1), datetime(1815,1,1)],				# YYYY/(Y|YY|YYYY)
 			'1814/21': [datetime(1814,1,1), datetime(1822,1,1)],			# YYYY/(Y|YY|YYYY)
 			'1815/1901': [datetime(1815,1,1), datetime(1902,1,1)],			# YYYY/(Y|YY|YYYY)
@@ -37,7 +37,7 @@ class TestDateCleaners(unittest.TestCase):
 			'1850 Mar': [datetime(1850,3,1), datetime(1850,4,1)],			# YYYY Mon
 			'1851 April 02': [datetime(1851,4,2), datetime(1851,4,3)],		# YYYY Month DD
 		}
-		
+
 		for value, expected in tests.items():
 			date_range = extracters.cleaners.date_cleaner(value)
 			self.assertIsInstance(date_range, list)


### PR DESCRIPTION
This PR fixes two bugs in date-related functions in `extracters.cleaners`:

* Fix `date_cleaner` so that the results are *always* a half-closed range
* Fix a bug in handling 'YYYY/Y' date formats

Tests are added for the date formats supported by `date_cleaner`.