### PR TITLE
Event refactoring

### DIFF
--- a/extracters/aata_data.py
+++ b/extracters/aata_data.py
@@ -5,7 +5,6 @@ running a bonobo pipeline for converting AATA XML data into JSON-LD.
 
 # AATA Extracters
 
-import os
 import sys
 import pprint
 import itertools

--- a/extracters/knoedler_linkedart.py
+++ b/extracters/knoedler_linkedart.py
@@ -167,9 +167,8 @@ def make_la_person(data: dict):
 		act.timespan = ts
 		who.carried_out = act
 
-	if data.get('events'):
-		for event in data['events']:
-			who.carried_out = event
+	for event in data.get('events', []):
+		who.carried_out = event
 
 	if data.get('birth'):
 		b = model.Birth()

--- a/tests/test_aata_pipeline.py
+++ b/tests/test_aata_pipeline.py
@@ -210,6 +210,15 @@ class TestAATAPipelineOutput(unittest.TestCase):
 			'Organization': 'model-org'
 		}
 		output = self.run_pipeline(models, input_path)
+# 		print('=========================================================================')
+# 		for dr in output:
+# 			print(f'# /{dr}')
+# 			for fn in output[dr]:
+# 				print('-------------------------------------------------------------------------')
+# 				print(f'### {fn}')
+# 				pprint.pprint(output[dr][fn])
+# 		print('=========================================================================')
+
 		self.assertEqual(len(output), 3)
 
 		lo_model = models['LinguisticObject']

--- a/tests/test_aata_pipeline.py
+++ b/tests/test_aata_pipeline.py
@@ -210,15 +210,6 @@ class TestAATAPipelineOutput(unittest.TestCase):
 			'Organization': 'model-org'
 		}
 		output = self.run_pipeline(models, input_path)
-# 		print('=========================================================================')
-# 		for dr in output:
-# 			print(f'# /{dr}')
-# 			for fn in output[dr]:
-# 				print('-------------------------------------------------------------------------')
-# 				print(f'### {fn}')
-# 				pprint.pprint(output[dr][fn])
-# 		print('=========================================================================')
-
 		self.assertEqual(len(output), 3)
 
 		lo_model = models['LinguisticObject']


### PR DESCRIPTION
Refactor the modeling of (sub-)events so that they belong to the article, not the actor.

This will depend on merging of article data to get the correct merged output in the future, but that's already true with other data being produced.