### PR TITLE
AATA Updates

### DIFF
--- a/knoedler.py
+++ b/knoedler.py
@@ -9,7 +9,8 @@ import bonobo_sqlalchemy
 from pipeline.nodes.basic import AddArchesModel, AddFieldNames, Serializer, deep_copy, Offset, add_uuid, Trace
 from pipeline.projects.knoedler.data import *
 from pipeline.projects.knoedler.linkedart import *
-from pipeline.io.arches import ArchesWriter, FileWriter
+from pipeline.io.file import FileWriter
+from pipeline.io.arches import ArchesWriter
 from pipeline.linkedart import make_la_person
 from settings import *
 

--- a/pipeline/io/arches.py
+++ b/pipeline/io/arches.py
@@ -1,7 +1,3 @@
-import os
-import os.path
-import hashlib
-
 import requests
 from bonobo.config import Configurable, Option
 

--- a/pipeline/io/arches.py
+++ b/pipeline/io/arches.py
@@ -6,28 +6,6 @@ import requests
 from bonobo.config import Configurable, Option
 from pipeline.util import ExclusiveValue
 
-class FileWriter(Configurable):
-	directory = Option(default="output")
-
-	def __call__(self, data: dict):
-		d = data['_OUTPUT']
-		uuid = data['uuid']
-		dr = os.path.join(self.directory, data['_ARCHES_MODEL'])
-		with ExclusiveValue(dr):
-			if not os.path.exists(dr):
-				os.mkdir(dr)
-		ddr = os.path.join(dr, uuid)
-		with ExclusiveValue(ddr):
-			if not os.path.exists(ddr):
-				os.mkdir(ddr)
-			h = hashlib.md5(d.encode('utf-8')).hexdigest()
-			fn = os.path.join(ddr, "%s.json" % (h,))
-			if not os.path.exists(fn):
-				fh = open(fn, 'w')
-				fh.write(d)
-				fh.close()
-			return data
-
 class ArchesWriter(Configurable):
 	endpoint = Option(default="http://localhost:8001/resources/")
 	auth_endpoint = Option(default="http://localhost:8001/o/token/")

--- a/pipeline/io/arches.py
+++ b/pipeline/io/arches.py
@@ -4,7 +4,6 @@ import hashlib
 
 import requests
 from bonobo.config import Configurable, Option
-from pipeline.util import ExclusiveValue
 
 class ArchesWriter(Configurable):
 	endpoint = Option(default="http://localhost:8001/resources/")

--- a/pipeline/io/file.py
+++ b/pipeline/io/file.py
@@ -1,11 +1,29 @@
 import os
 import os.path
 import hashlib
+import json
+import pprint
+from pipeline.util import CromObjectMerger
 
 from bonobo.config import Configurable, Option
 from pipeline.util import ExclusiveValue
+from cromulent import model, vocab, reader
 
 class FileWriter(Configurable):
+	directory = Option(default="output")
+
+	def __call__(self, data: dict):
+		d = data['_OUTPUT']
+		dr = os.path.join(self.directory, data['_ARCHES_MODEL'])
+		if not os.path.exists(dr):
+			os.mkdir(dr)
+		fn = os.path.join(dr, "%s.json" % data['uuid'])
+		fh = open(fn, 'w')
+		fh.write(d)
+		fh.close()
+		return data
+
+class MultiFileWriter(Configurable):
 	directory = Option(default="output")
 
 	def __call__(self, data: dict):
@@ -25,4 +43,40 @@ class FileWriter(Configurable):
 				fh = open(fn, 'w')
 				fh.write(d)
 				fh.close()
+			return data
+
+class MergingFileWriter(Configurable):
+	directory = Option(default="output")
+
+	def __call__(self, data: dict):
+		d = data['_OUTPUT']
+		dr = os.path.join(self.directory, data['_ARCHES_MODEL'])
+		merger = CromObjectMerger()
+		with ExclusiveValue(dr):
+			if not os.path.exists(dr):
+				os.mkdir(dr)
+			fn = os.path.join(dr, "%s.json" % data['uuid'])
+			if os.path.exists(fn):
+				r = reader.Reader()
+				with open(fn, 'r') as fh:
+					content = fh.read()
+					try:
+						m = r.read(content)
+						n = r.read(d)
+						print('========================= MERGING =========================')
+						print('merging objects:')
+						print(f'- {m}')
+						print(f'- {n}')
+						merger.merge(m, n)
+					except model.DataError:
+						print('Exception caught while merging data:')
+						print(d)
+						print(content)
+						raise
+
+					factory = data['_CROM_FACTORY']
+					d = factory.toString(m, False)
+			fh = open(fn, 'w')
+			fh.write(d)
+			fh.close()
 			return data

--- a/pipeline/io/file.py
+++ b/pipeline/io/file.py
@@ -1,13 +1,11 @@
 import os
 import os.path
 import hashlib
-import json
-import pprint
 from pipeline.util import CromObjectMerger
 
 from bonobo.config import Configurable, Option
 from pipeline.util import ExclusiveValue
-from cromulent import model, vocab, reader
+from cromulent import model, reader
 
 class FileWriter(Configurable):
 	directory = Option(default="output")

--- a/pipeline/io/file.py
+++ b/pipeline/io/file.py
@@ -1,0 +1,28 @@
+import os
+import os.path
+import hashlib
+
+from bonobo.config import Configurable, Option
+from pipeline.util import ExclusiveValue
+
+class FileWriter(Configurable):
+	directory = Option(default="output")
+
+	def __call__(self, data: dict):
+		d = data['_OUTPUT']
+		uuid = data['uuid']
+		dr = os.path.join(self.directory, data['_ARCHES_MODEL'])
+		with ExclusiveValue(dr):
+			if not os.path.exists(dr):
+				os.mkdir(dr)
+		ddr = os.path.join(dr, uuid)
+		with ExclusiveValue(ddr):
+			if not os.path.exists(ddr):
+				os.mkdir(ddr)
+			h = hashlib.md5(d.encode('utf-8')).hexdigest()
+			fn = os.path.join(ddr, "%s.json" % (h,))
+			if not os.path.exists(fn):
+				fh = open(fn, 'w')
+				fh.write(d)
+				fh.close()
+			return data

--- a/pipeline/io/xml.py
+++ b/pipeline/io/xml.py
@@ -1,11 +1,11 @@
 import os
 import sys
-import lxml.etree
 import fnmatch
+import lxml.etree
 
 from bonobo.constants import NOT_MODIFIED
 from bonobo.nodes.io.file import FileReader
-from bonobo.config import Configurable, Method, Option, Service
+from bonobo.config import Configurable, Option, Service
 
 class MatchingFiles(Configurable):
 	'''
@@ -35,7 +35,7 @@ class XMLReader(FileReader):
 	'''
 	xpath = Option(str, required=True)
 
-	def read(self, file, *, fs):
+	def read(self, file):
 		root = lxml.etree.parse(file)
 		for e in root.xpath(self.xpath):
 			yield e
@@ -89,6 +89,7 @@ class FilterXPathEqual(Configurable):
 		for t in e.xpath(self.xpath):
 			if t.text == self.value:
 				return NOT_MODIFIED
+		return None
 
 def print_xml_element(e):
 	s = lxml.etree.tostring(e).decode('utf-8')

--- a/pipeline/nodes/basic.py
+++ b/pipeline/nodes/basic.py
@@ -82,10 +82,11 @@ def get_or_set_uuid(uid, uuid_cache):
 # This is so far just internal
 @use('uuid_cache')
 def add_uuid(thing: dict, uuid_cache=None):
-	# Need access to select from the uuid_cache
-	uid = thing['uid']
-	uuid = get_or_set_uuid(uid, uuid_cache)
-	thing['uuid'] = uuid
+	if 'uuid' not in thing:
+		# Need access to select from the uuid_cache
+		uid = thing['uid']
+		uuid = get_or_set_uuid(uid, uuid_cache)
+		thing['uuid'] = uuid
 	return thing
 
 @use('aat')

--- a/pipeline/projects/aata.py
+++ b/pipeline/projects/aata.py
@@ -10,20 +10,21 @@ import pprint
 import itertools
 
 import iso639
+import lxml.etree
+from sqlalchemy import create_engine
+from langdetect import detect
+
 import bonobo
 from bonobo.config import Configurable, Option, use
 from bonobo.constants import NOT_MODIFIED
 from bonobo.nodes import Limit
-import lxml.etree
-from sqlalchemy import create_engine
-from langdetect import detect
 
 import settings
 from cromulent import model, vocab
 from pipeline.util import identity
 from pipeline.util.cleaners import date_cleaner
 from pipeline.io.file import MultiFileWriter, MergingFileWriter
-from pipeline.io.arches import ArchesWriter
+# from pipeline.io.arches import ArchesWriter
 from pipeline.linkedart import \
 			MakeLinkedArtAbstract, \
 			MakeLinkedArtLinguisticObject, \
@@ -427,7 +428,7 @@ class ExtractKeyedValues(Configurable):
 	'''
 	key = Option(str, required=True)
 	include_parent = Option(bool, default=True)
-	
+
 	def __init__(self, *v, **kw):
 		'''
 		Sets the __name__ property to include the relevant options so that when the

--- a/pipeline/projects/aata.py
+++ b/pipeline/projects/aata.py
@@ -21,7 +21,7 @@ from bonobo.nodes import Limit
 
 import settings
 from cromulent import model, vocab
-from pipeline.util import identity
+from pipeline.util import identity, ExtractKeyedValues
 from pipeline.util.cleaners import date_cleaner
 from pipeline.io.file import MultiFileWriter, MergingFileWriter
 # from pipeline.io.arches import ArchesWriter
@@ -419,32 +419,6 @@ def add_imprint_orgs(data, uuid_cache=None):
 		organizations.append(org)
 	data['organizations'] = organizations
 	return data
-
-class ExtractKeyedValues(Configurable):
-	'''
-	Given a `dict` representing an some object, extract an array of `dict` values from
-	the `key` member. To each of the extracted dictionaries, add a 'parent_data' key with
-	the value of the original dictionary. Yield each extracted dictionary.
-	'''
-	key = Option(str, required=True)
-	include_parent = Option(bool, default=True)
-
-	def __init__(self, *v, **kw):
-		'''
-		Sets the __name__ property to include the relevant options so that when the
-		bonobo graph is serialized as a GraphViz document, different objects can be
-		visually differentiated.
-		'''
-		super().__init__(*v, **kw)
-		self.__name__ = f'{type(self).__name__} ({self.key})'
-
-	def __call__(self, data):
-		for a in data.get(self.key, []):
-			child = {k: v for k, v in a.items()}
-			child.update({
-				'parent_data': data,
-			})
-			yield child
 
 class CleanDateToSpan(Configurable):
 	'''

--- a/pipeline/projects/aata.py
+++ b/pipeline/projects/aata.py
@@ -22,7 +22,8 @@ import settings
 from cromulent import model, vocab
 from pipeline.util import identity
 from pipeline.util.cleaners import date_cleaner
-from pipeline.io.arches import FileWriter, ArchesWriter
+from pipeline.io.file import FileWriter
+from pipeline.io.arches import ArchesWriter
 from pipeline.linkedart import \
 			MakeLinkedArtAbstract, \
 			MakeLinkedArtLinguisticObject, \

--- a/pipeline/projects/aata.py
+++ b/pipeline/projects/aata.py
@@ -22,7 +22,7 @@ import settings
 from cromulent import model, vocab
 from pipeline.util import identity
 from pipeline.util.cleaners import date_cleaner
-from pipeline.io.file import FileWriter
+from pipeline.io.file import MultiFileWriter, MergingFileWriter
 from pipeline.io.arches import ArchesWriter
 from pipeline.linkedart import \
 			MakeLinkedArtAbstract, \
@@ -656,7 +656,7 @@ def make_aata_abstract(data):
 		abstract_dict = {k: v for k, v in a.items() if k not in ('language',)}
 
 		abstract.content = a.get('content')
-		abstract.classified_as = model.Type(
+		abstract.classified_as = model.Type( # TODO: change to vocab.Abstract()
 			ident='http://vocab.getty.edu/aat/300026032',
 			label='Abstract' # TODO: is this the right aat URI?
 		)
@@ -868,11 +868,13 @@ class AATAFilePipeline(AATAPipeline):
 		output_path = kwargs.get('output_path')
 		if debug:
 			self.serializer	= Serializer(compact=False)
-			self.writer		= FileWriter(directory=output_path)
+			self.writer		= MergingFileWriter(directory=output_path)
+			# self.writer	= MultiFileWriter(directory=output_path)
 			# self.writer	= ArchesWriter()
 		else:
 			self.serializer	= Serializer(compact=True)
-			self.writer		= FileWriter(directory=output_path)
+			self.writer		= MergingFileWriter(directory=output_path)
+			# self.writer	= MultiFileWriter(directory=output_path)
 			# self.writer	= ArchesWriter()
 
 

--- a/pipeline/util/__init__.py
+++ b/pipeline/util/__init__.py
@@ -1,5 +1,7 @@
 from threading import Lock
 from contextlib import ContextDecorator
+import settings
+import pipeline.io.arches
 
 def identity(d):
 	'''
@@ -37,3 +39,12 @@ class ExclusiveValue(ContextDecorator):
 
 	def __exit__(self, *exc):
 		self.get_lock().release()
+
+def configured_arches_writer():
+	return pipeline.io.arches.ArchesWriter(
+		endpoint=settings.arches_endpoint,
+		auth_endpoint=settings.arches_auth_endpoint,
+		username=settings.arches_endpoint_username,
+		password=settings.arches_endpoint_password,
+		client_id=settings.arches_client_id
+	)

--- a/settings.py
+++ b/settings.py
@@ -12,6 +12,12 @@ arches_models = {
 	"Organization": "edbee5e8-2e41-11e9-bc39-a4d18cec433a"
 }
 
+arches_endpoint = os.environ.get('GETTY_PIPELINE_ARCHES_ENDPOINT', 'http://localhost:8001/resources/')
+arches_endpoint_username = os.environ.get('GETTY_PIPELINE_ARCHES_USERNAME', 'admin')
+arches_endpoint_password = os.environ.get('GETTY_PIPELINE_ARCHES_PASSWORD', 'admin')
+arches_auth_endpoint = os.environ.get('GETTY_PIPELINE_ARCHES_AUTH_ENDPOINT', 'http://localhost:8001/o/token/')
+arches_client_id = os.environ.get('GETTY_PIPELINE_ARCHES_CLIENT_ID', 'OaGs0HfnBNd2VpI4Hnrc8nhOSTbnV1Q3O1CPjlX6')
+
 aata_data_path = os.environ.get('GETTY_PIPELINE_AATA_INPUT', '/data/input/aata')
 data_path = os.environ.get('GETTY_PIPELINE_INPUT', '/data/input/provenance/knoedler')
 output_file_path = os.environ.get('GETTY_PIPELINE_OUTPUT', '/data2/output/provenance/knoedler')

--- a/tests/test_merging_file_writer.py
+++ b/tests/test_merging_file_writer.py
@@ -1,0 +1,66 @@
+import unittest
+import os
+import json
+import pprint
+from cromulent import model, vocab
+from pipeline.io.file import MergingFileWriter
+from cromulent.model import factory
+
+class MergingFileWriterTests(unittest.TestCase):
+	def setUp(self):
+		self.path = '/tmp/pipeline_tests'
+		if not os.path.exists(self.path):
+			os.mkdir(self.path)
+		f = self.expected_file('0001')
+		os.remove(f)
+
+	def expected_file(self, id):
+		f = os.path.join(self.path, 'test-model', f'{id}.json')
+		return f
+
+	def setUp(self):
+		self.path = '/tmp/pipeline_tests'
+		if not os.path.exists(self.path):
+			os.mkdir(self.path)
+		self.writer = MergingFileWriter(directory=self.path)
+
+	def write_obj1(self, id):
+		'''Writes a Person model object with a label and a PrimaryName'''
+		p1 = vocab.Person(ident=f'urn:{id}', label='Greg')
+		p1.identified_by = vocab.PrimaryName(content='Gregory Williams')
+		w = MergingFileWriter(directory=self.path)
+		d = self.obj_to_dict(p1, id)
+		self.writer(d)
+
+	def write_obj2(self, id):
+		'''Writes a Person model object with a 'born' event'''
+		p2 = vocab.Person(ident='urn:foo')
+		p2.born = model.Birth()
+		w = MergingFileWriter(directory=self.path)
+		d = self.obj_to_dict(p2, id)
+		self.writer(d)
+
+	def obj_to_dict(self, o, uuid):
+		d = {
+			'_ARCHES_MODEL': 'test-model',
+			'_CROM_FACTORY': factory,
+			'uuid': uuid,
+			'_OUTPUT': factory.toString(o, False)
+		}
+		return d
+
+	def test_merge(self):
+		id = '0001'
+		self.write_obj1(id)
+		self.write_obj2(id)
+		f = self.expected_file(id)
+		print(f'# expected file {f}')
+		self.assertTrue(os.path.exists(f), 'merged file exists')
+		with open(f) as f:
+			j = json.load(f)
+			pprint.pprint(j)
+			self.assertEqual(j.get('_label'), 'Greg')
+			self.assertIsInstance(j.get('born'), dict)
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
This includes a bunch of miscellaneous changes to the pipeline and AATA code that improve the state of the code and prepare things for the addition of the PIR project:

* Updated pipeline to produce event relationships that flow from the article/abstract
* Update `add_uuid` to be a no-op if a uuid key already exists
* Added a convenience constructor for `ArchesWriter` based on values from settings
* Add new variables to `settings` module
* Created `pipeline.io.file` module with `FileWriter` and new `MultiFileWriter`
* Reorganize code into more appropriate modules
