### PR TITLE
Improve handling of attribute-based identity in CromObjectMerger

### DIFF
--- a/pipeline/util/__init__.py
+++ b/pipeline/util/__init__.py
@@ -171,8 +171,8 @@ class CromObjectMerger:
 				if isinstance(v, classes):
 					if hasattr(v, 'content'):
 						identified[getattr(v, attr)].append(v)
-					handled = True
-					break
+						handled = True
+						break
 			if not handled:
 				if hasattr(v, 'id'):
 					identified[v.id].append(v)

--- a/tests/test_merging_file_writer.py
+++ b/tests/test_merging_file_writer.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import json
+from contextlib import suppress
 import pprint
 from cromulent import model, vocab
 from pipeline.io.file import MergingFileWriter
@@ -9,20 +10,17 @@ from cromulent.model import factory
 class MergingFileWriterTests(unittest.TestCase):
 	def setUp(self):
 		self.path = '/tmp/pipeline_tests'
+		self.writer = MergingFileWriter(directory=self.path)
 		if not os.path.exists(self.path):
 			os.mkdir(self.path)
-		f = self.expected_file('0001')
-		os.remove(f)
+		for uuid in ('0001', '0002'):
+			f = self.expected_file(uuid)
+			with suppress(FileNotFoundError):
+				os.remove(f)
 
 	def expected_file(self, id):
 		f = os.path.join(self.path, 'test-model', f'{id}.json')
 		return f
-
-	def setUp(self):
-		self.path = '/tmp/pipeline_tests'
-		if not os.path.exists(self.path):
-			os.mkdir(self.path)
-		self.writer = MergingFileWriter(directory=self.path)
 
 	def write_obj1(self, id):
 		'''Writes a Person model object with a label and a PrimaryName'''
@@ -60,6 +58,38 @@ class MergingFileWriterTests(unittest.TestCase):
 			j = json.load(f)
 			self.assertEqual(j.get('_label'), 'Greg')
 			self.assertIsInstance(j.get('born'), dict)
+
+	def _write_two_objects(self, p1, p2, uuid):
+		self.writer(self.obj_to_dict(p1, uuid))
+		self.writer(self.obj_to_dict(p2, uuid))
+
+	def _new_object(self, uuid):
+		p = vocab.Person(ident=f'urn:{uuid}')
+		p.identified_by = vocab.Identifier(content='Gregory Williams')
+		return p
+
+	def test_merge_multiple_identifiers(self):
+		'''
+		When merging two objects with the same Identifier content, ensure that the
+		resulting object only has one Identifier.
+		'''
+		factory.auto_id_type = 'uuid'
+		uri = 'tag:kasei.us,2019,test'
+
+		uuid = '0002'
+		p1 = self._new_object(uuid)
+		p2 = self._new_object(uuid)
+
+		self._write_two_objects(p1, p2, uuid)
+		f = self.expected_file(uuid)
+		print(f'# expected file {f}')
+		self.assertTrue(os.path.exists(f), 'merged file exists')
+		with open(f) as f:
+			j = json.load(f)
+			ids = j['identified_by']
+			self.assertEqual(len(ids), 1)
+			self.assertEqual(ids[0]['content'], 'Gregory Williams')
+		
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
This should fix some cases where merging objects resulted in empty `Identifier`s and `Name`s (DEV-2062).

The fix here is in the use of the `handled` flag when a merge process uses attribute-based identity. The previous code wrongly called `continue`. The correct approach is to `break` *and also* skip subsequent handling in the enclosing loop.