### PR TITLE
Base scripts/reorganize_json.py on filenames instead of parsed JSON

### DIFF
--- a/scripts/reorganize_json.py
+++ b/scripts/reorganize_json.py
@@ -5,6 +5,7 @@ For every JSON file identified in ARGV, ensure that it is located in the
 correct directory structure. If it isn't, move it to the correct directory.
 '''
 
+import re
 import sys
 import json
 from pathlib import Path
@@ -22,25 +23,20 @@ if len(sys.argv) > 1:
 else:
 	files = sorted(Path(output_file_path).rglob('*.json'))
 
+uuid_re = re.compile('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.json')
 for filename in files:
 	p = Path(filename)
-	with open(filename, 'r') as fh:
-		data = json.load(fh)
-		try:
-			uu = data['id']
-		except KeyError as e:
-			print(f'*** ERROR:{filename}: {e}')
-			continue
-		if not uu.startswith('urn:uuid:'):
-			raise Exception(f"file doesn't have a valid top-level UUID: {filename}")
-		correct_partition = uu[9:11]
-		if len(p.parent.name) != 2:
-			raise Exception(f"file does not appear to be in a 1-byte partition directory: {p.parent.name}")
-		correct_path = p.parent.parent.joinpath(correct_partition)
-		correct_filename = correct_path.joinpath(p.name)
-		if p != correct_filename:
-			p.replace(correct_filename)
-# 			print(f'mv {p} {correct_filename}')
-		else:
-			pass
-# 			print(f'Already in the correct directory: {p}')
+	m = uuid_re.match(p.name)
+	if not m:
+		continue
+	correct_partition = p.name[0:2]
+	if len(p.parent.name) != 2:
+		raise Exception(f"file does not appear to be in a 1-byte partition directory: {p.parent.name}")
+	correct_path = p.parent.parent.joinpath(correct_partition)
+	correct_filename = correct_path.joinpath(p.name)
+	if p != correct_filename:
+		p.replace(correct_filename)
+# 		print(f'mv {p} {correct_filename}')
+	else:
+		pass
+# 		print(f'Already in the correct directory: {p}')


### PR DESCRIPTION
Save a bit of IO and CPU time by avoiding JSON parsing.