### PR TITLE
Improve performance of generating metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ nq: jsonlist
 	echo 'Transcoding JSON-LD to N-Quads...'
 	cat $(GETTY_PIPELINE_TMP_PATH)/json_files.txt | xargs -n 256 -P 16 $(PYTHON) ./scripts/json2nq.py $(GETTY_PIPELINE_TMP_PATH)/linked-art.json
 	find $(GETTY_PIPELINE_OUTPUT) -name '[0-9a-f][0-9a-f]*.nq' | xargs -n 256 cat | gzip - > $(GETTY_PIPELINE_OUTPUT)/all.nq.gz
+	gzip -k $(GETTY_PIPELINE_OUTPUT)/meta.nq
 
 pirdata:
 	mkdir -p $(GETTY_PIPELINE_TMP_PATH)/pipeline


### PR DESCRIPTION
Pyld does not seem up to the task of converting the huge list of graph names into N-Quads, so instead we generate N-Quads manually.