### PR TITLE
Only assert auction portal links when they look like an HTTP URL

### DIFF
--- a/pipeline/projects/provenance/__init__.py
+++ b/pipeline/projects/provenance/__init__.py
@@ -182,6 +182,8 @@ def populate_auction_event(data, auction_locations):
 		url = p['portal_url']
 		if url.startswith('http'):
 			auction.referred_to_by = vocab.WebPage(ident=url)
+		else:
+			warnings.warn(f'*** Portal URL value does not appear to be a valid URL: {url}')
 
 	if ts:
 		auction.timespan = ts

--- a/pipeline/projects/provenance/__init__.py
+++ b/pipeline/projects/provenance/__init__.py
@@ -180,7 +180,8 @@ def populate_auction_event(data, auction_locations):
 
 	for p in data.get('portal', []):
 		url = p['portal_url']
-		auction.referred_to_by = vocab.WebPage(ident=url)
+		if url.startswith('http'):
+			auction.referred_to_by = vocab.WebPage(ident=url)
 
 	if ts:
 		auction.timespan = ts


### PR DESCRIPTION
This seems like problematic upstream data, but the first step to not producing bad downstream data is probably to ignore values that doesn't look like actual "links".