### PR TITLE
Add test to verify the collection and handling of prev/post sales data

### DIFF
--- a/pipeline/projects/provenance/util.py
+++ b/pipeline/projects/provenance/util.py
@@ -68,6 +68,17 @@ def add_pir_object_uri(data, parent):
 	data['uri'] = object_uri(parent)
 	return data
 
+def prev_post_sales_rewrite_map(map_data):
+	post_sale_rewrite_map = map_data.copy()
+	also_rewrite = {}
+	also_rewrite_suffixes = ['Production', 'Destruction', 'VisualItem']
+	also_rewrite_suffixes += [f'Production-{i}' for i in range(6)]
+	for k, v in post_sale_rewrite_map.items():
+		for suffix in also_rewrite_suffixes:
+			also_rewrite[f'{k}-{suffix}'] = f'{v}-{suffix}'
+	post_sale_rewrite_map.update(also_rewrite)
+	return post_sale_rewrite_map
+
 class SalesTree:
 	'''
 	This class is used to represent the repeated sales of objects in provenance data.
@@ -104,20 +115,20 @@ class SalesTree:
 		for src in self.nodes.keys():
 			key, _ = self.canonical_key(src)
 			components[key] += 1
-		print(f'Post sales records connected component sizes (top {limit}):')
+# 		print(f'Post sales records connected component sizes (top {limit}):')
 		for key, count in components.most_common(limit):
 			uri = pir_uri('OBJECT', *key)
-			print(f'{count}\t{key!s:>40}\t\t{uri}')
+# 			print(f'{count}\t{key!s:>40}\t\t{uri}')
 			yield key
 
 	def add_edge(self, src, dst):
 		i = self.add_node(src)
 		j = self.add_node(dst)
-		if i in self.outgoing_edges:
-			if self.outgoing_edges[i] == j:
-				warnings.warn(f'*** re-asserted sale edge: {src!s:<40} -> {dst}')
-			else:
-				warnings.warn(f'*** {src} already has an outgoing edge: {self.outgoing_edges[i]}')
+# 		if i in self.outgoing_edges:
+# 			if self.outgoing_edges[i] == j:
+# 				warnings.warn(f'*** re-asserted sale edge: {src!s:<40} -> {dst}')
+# 			else:
+# 				warnings.warn(f'*** {src} already has an outgoing edge: {self.outgoing_edges[i]}')
 		self.outgoing_edges[i] = j
 
 	def __iter__(self):

--- a/scripts/rewrite_post_sales_uris.py
+++ b/scripts/rewrite_post_sales_uris.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from settings import output_file_path
 from pipeline.util.rewriting import rewrite_output_files, JSONValueRewriter
+from pipeline.projects.provenance.util import prev_post_sales_rewrite_map
 
 if len(sys.argv) < 2:
 	cmd = sys.argv[0]
@@ -23,13 +24,8 @@ print(f'Rewriting post-sales URIs ...')
 rewrite_map_filename = sys.argv[1]
 with open(rewrite_map_filename, 'r') as f:
 	post_sale_rewrite_map = json.load(f)
-
-	also_rewrite = {}
-	also_rewrite_suffixes = ['Production', 'Destruction', 'VisualItem']
-	also_rewrite_suffixes += [f'Production-{i}' for i in range(6)]
-	for k, v in post_sale_rewrite_map.items():
-		for suffix in also_rewrite_suffixes:
-			also_rewrite[f'{k}-{suffix}'] = f'{v}-{suffix}'
-	post_sale_rewrite_map.update(also_rewrite)
+	post_sale_rewrite_map = prev_post_sales_rewrite_map(post_sale_rewrite_map)
+	print('Post sales rewrite map:')
+	pprint.pprint(post_sale_rewrite_map)
 	r = JSONValueRewriter(post_sale_rewrite_map)
 	rewrite_output_files(r, parallel=True)

--- a/tests/test_pir_modeling_prevsale_merge.py
+++ b/tests/test_pir_modeling_prevsale_merge.py
@@ -9,14 +9,63 @@ import pprint
 import inspect
 from pathlib import Path
 import warnings
+from cromulent import reader
+from cromulent.model import factory
 
+from pipeline.util import CromObjectMerger
+from pipeline.util.rewriting import JSONValueRewriter
+from pipeline.projects.provenance.util import prev_post_sales_rewrite_map
 from tests import TestProvenancePipelineOutput
 
 class PIRModelingTest_PrevSaleMerge(TestProvenancePipelineOutput):
-	# TODO: add tests for prevsale_merge; this is different than the above tests,
-	#       in that it requires post-processing that is normally carried out by the
-	#       `rewrite_post_sales_uris.py` script.
-	pass
+	def merge_objects(self, objects):
+		rewrite_map_data = self.prev_post_sales_map
+		post_sale_rewrite_map = prev_post_sales_rewrite_map(rewrite_map_data)
+		r = JSONValueRewriter(post_sale_rewrite_map)
+		for k in list(objects.keys()):
+			data = objects[k]
+			updated = r.rewrite(data)
+			ident = updated['id']
+			if k != ident:
+				if ident in objects:
+					read = reader.Reader()
+					m = read.read(json.dumps(objects[ident]))
+					n = read.read(json.dumps(updated))
+					merger = CromObjectMerger()
+					m = merger.merge(m, n)
+					objects[ident] = json.loads(factory.toString(m, False))
+				else:
+					objects[ident] = updated
+				del(objects[k])
+
+	def test_modeling_prev_post_sales_merge(self):
+		'''
+		Test that prev/post sales data is collected properly during the pipeline run,
+		and that it leads to correctly merged HumanMadeObjects after post-processing.
+		'''
+		output = self.run_pipeline('prevsale_merge')
+		objects = output['model-object']
+
+		# after the pipeline run, 2 objects are recorded as being the same as a prev sale
+		# object (indicating that after merging there will be either 1 or 2 objects).
+		self.assertEqual(len(self.prev_post_sales_map), 2)
+
+		# there are records for 3 objects, and each is a member of only one auction lot,
+		# and all auction lots are distinct
+		self.assertEqual(len(objects), 3)
+		auction_lots = set([l['id'] for hmo in objects.values() for l in hmo['member_of']])
+		self.assertEqual(len(auction_lots), 3)
+		for hmo in objects.values():
+			self.assertEqual(len(hmo['member_of']), 1)
+
+		# after merging prev/post sales, there is only one object
+		self.merge_objects(objects)
+		self.assertEqual(len(objects), 1)
+
+		# and the single object is a member of all 3 auction lots
+		hmo = next(iter(objects.values()))
+		auction_lots = set([l['id'] for l in hmo['member_of']])
+		self.assertEqual(len(auction_lots), 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There was a bit of refactoring involved in getting the prev/post sales handling easily testable. The prev/post sales records are now available to the testing processing without saving it as a file, and it can then be used by the rewriting code which has also been refactored to be in `pipeline.projects.provenance.util` instead of directly in `scripts/rewrite_post_sales_uris.py`.