### PR TITLE
Refactor handling of static instances

### DIFF
--- a/pipeline/projects/aata.py
+++ b/pipeline/projects/aata.py
@@ -877,6 +877,7 @@ def filter_abstract_authors(data: dict):
 class AATAPipeline(PipelineBase):
 	'''Bonobo-based pipeline for transforming AATA data from XML into JSON-LD.'''
 	def __init__(self, input_path, abstracts_pattern, journals_pattern, series_pattern, **kwargs):
+		self.uid_tag_prefix = UID_TAG_PREFIX
 		super().__init__()
 		
 		vocab.register_vocab_class('VolumeNumber', {'parent': model.Identifier, 'id': '300265632', 'label': 'Volume'})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-#cromulent==0.14.0
+#cromulent==0.15.1
 git+git://github.com/thegetty/crom@master
 python-dateutil==2.8.0
 bonobo==0.6.4

--- a/tests/test_pir_modeling_attrib_mod.py
+++ b/tests/test_pir_modeling_attrib_mod.py
@@ -42,13 +42,12 @@ class PIRModelingTest_AttributionModifiers(TestProvenancePipelineOutput):
 		# was "copy after" an original painting.
 		self.assertEqual(len(objects), 10)
 		
-		# there are 16 people:
+		# there are 15 people:
 		# 	"Pierre André Joseph Knyff" (seller)
 		# 	"Jeffrey, Henry" (seller)
 		# 	"Schgosdass" (artist, formerly attributed to)
 		# 	"HOLBEIN, HANS (THE YOUNGER)" (style of)
 		# 	"SAVERY (XAVERY)" (artist, attributed to)
-		# 	"Frits Lugt" (static instance emitted by the pipeline)
 		# 	"DYCK, ANTHONIE VAN" (copy after)
 		# 	"Simpson" (buyer)
 		# 	"POUSSIN, NICOLAS" (circle of)
@@ -59,15 +58,14 @@ class PIRModelingTest_AttributionModifiers(TestProvenancePipelineOutput):
 		# 	"Giot" (buyer)
 		# 	"H Sudn [?]" (seller)
 		# 	"CORNEILLE, JEAN BAPTISTE" (artist, possibly by)
-		self.assertEqual(len(people), 16)
+		self.assertEqual(len(people), 15)
 
-		# there are 5 groups:
-		# 	'Getty Research Institute' (static instance emitted by the pipeline)
+		# there are 4 groups:
 		# 	'FollowerGroup of artist “RUBENS, PETER PAUL”' (influencer of the formation of the "follower of" group)
 		# 	'School of artist “RUBENS, PETER PAUL”' (influencer of the formation of the "school of" group)
 		# 	'Workshop of artist “WEST, BENJAMIN”' (influencer of the formation of the "workshop of" group)
 		# 	'Circle of artist “POUSSIN, NICOLAS”' (influencer of the formation of the "circle of" group)
-		self.assertEqual(len(groups), 5)
+		self.assertEqual(len(groups), 4)
 		
 		# 'style of' modifiers use an AttributeAssignment that classifies the 'influenced_by' property as being 'Style of'
 		style_of_obj = objects['tag:getty.edu,2019:digital:pipeline:provenance:REPLACE-WITH-UUID#OBJECT,Br-A2493,0029%5Bb%5D,1800-03-01']

--- a/tests/test_pir_modeling_buy_sell_mod.py
+++ b/tests/test_pir_modeling_buy_sell_mod.py
@@ -36,8 +36,7 @@ class PIRModelingTest_AttributionModifiers(TestProvenancePipelineOutput):
 		# was "copy after" an original painting.
 		self.assertEqual(len(objects), 5)
 		
-		# there are 17 people:
-		# 	"Frits Lugt" (static instance emitted by the pipeline)
+		# there are 16 people:
 		# 	"DUBBELS, HENDRIK JACOBSZ." (artist)
 		# 	"RUBENS, PETER PAUL" (artist)
 		# 	"PANINI, GIOVANNI PAOLO" (artist)
@@ -54,7 +53,7 @@ class PIRModelingTest_AttributionModifiers(TestProvenancePipelineOutput):
 		# 	"Gent, G.W." (seller, and)
 		# 	"Mackey, Mrs." (seller, for)
 		# 	"Nelthorpe" (seller, through)
-		self.assertEqual(len(people), 17)
+		self.assertEqual(len(people), 16)
 
 		# buyer 'for'/'through' is modeled an AGENT who carries out the payment and acquisition, and a BUYER who pays for the object and to whom the object's title is transferred
 		b_ft_obj = activities['tag:getty.edu,2019:digital:pipeline:provenance:REPLACE-WITH-UUID#AUCTION-TX,Br-A450,1751-03-08,0044']

--- a/tests/test_pir_modeling_multiartist.py
+++ b/tests/test_pir_modeling_multiartist.py
@@ -20,22 +20,20 @@ class PIRModelingTest_MultiArtist(TestProvenancePipelineOutput):
 	def test_modeling_for_multi_artists(self):
 		'''
 		The object in this set has a production event that has 3 sub-events, pointing to
-		the three artists modeled as people. No other people are modeled in the dataset,
-		but 1 (Lugt) is a static instance serialized directly from the pipeline code.
+		the three artists modeled as people. No other people are modeled in the dataset.
 		'''
 		output = self.run_pipeline('multiartist')
 
 		objects = output['model-object']
 		people = output['model-person']
 		self.assertEqual(len(objects), 1)
-		self.assertEqual(len(people), 4)
+		self.assertEqual(len(people), 3)
 		people_ids = set([p['id'] for p in people.values()])
 		object = next(iter(objects.values()))
 		event = object['produced_by']
 		artists = [e['carried_out_by'][0] for e in event['part']]
 		artist_ids = set([a['id'] for a in artists])
-		static_ids = {pir_uri('PERSON', 'ULAN', 500321736)}
-		self.assertEqual(people_ids, artist_ids | static_ids)
+		self.assertEqual(people_ids, artist_ids)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Static instances are not managed by a new pipeline.projects.StaticInstanceHolder class
that records access to specific instances, and can therefore aid in only serializing
instances that actually relate to the produced data.

Pipeline subclasses can overload the setup of per-project static instances.