### PR TITLE
Remove extra ids from JSON-LD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ pirdata:
 	PYTHONPATH=`pwd` $(PYTHON) ./scripts/rewrite_post_sales_uris.py "${GETTY_PIPELINE_TMP_PATH}/post_sale_rewrite_map.json"
 	PYTHONPATH=`pwd` $(PYTHON) ./scripts/rewrite_uris_to_uuids.py 'tag:getty.edu,2019:digital:pipeline:provenance:REPLACE-WITH-UUID#' "${GETTY_PIPELINE_TMP_PATH}/uri_to_uuid_map.json"
 	ls $(GETTY_PIPELINE_OUTPUT) | PYTHONPATH=`pwd` xargs -n 1 -P 8 -I '{}' $(PYTHON) ./scripts/coalesce_json.py "${GETTY_PIPELINE_OUTPUT}/{}"
+	PYTHONPATH=`pwd` $(PYTHON) ./scripts/remove_meaningless_ids.py
 	find $(GETTY_PIPELINE_OUTPUT) -name '*.json' | PYTHONPATH=`pwd` xargs -n 256 -P 16 $(PYTHON) ./scripts/reorganize_json.py
 	find $(GETTY_PIPELINE_OUTPUT) -type d -empty -delete
 

--- a/pipeline/projects/provenance/__init__.py
+++ b/pipeline/projects/provenance/__init__.py
@@ -765,7 +765,7 @@ def add_acquisition(data, buyers, sellers, buy_sell_modifiers, make_la_person=No
 
 			own_info_source = owner_record.get('own_so')
 			if own_info_source:
-				note = vocab.SourceStatement(content=own_info_source, label=source_label)
+				note = vocab.SourceStatement(ident='', content=own_info_source, label=source_label)
 				tx.referred_to_by = note
 
 			ptx_data = tx_data.copy()
@@ -782,7 +782,7 @@ def related_procurement(current_tx, hmo, current_ts=None, buyer=None, seller=Non
 	and if the timespan `current_ts` is given, has temporal data to that effect. If
 	`previous` is `False`, this relationship is reversed.
 	'''
-	tx = vocab.Procurement()
+	tx = vocab.Procurement(ident='')
 	if current_tx:
 		if previous:
 			tx.ends_before_the_start_of = current_tx
@@ -790,9 +790,9 @@ def related_procurement(current_tx, hmo, current_ts=None, buyer=None, seller=Non
 			tx.starts_after_the_end_of = current_tx
 	modifier_label = 'Previous' if previous else 'Subsequent'
 	try:
-		pacq = model.Acquisition(label=f'{modifier_label} Acquisition of: “{hmo._label}”')
+		pacq = model.Acquisition(ident='', label=f'{modifier_label} Acquisition of: “{hmo._label}”')
 	except AttributeError:
-		pacq = model.Acquisition(label=f'{modifier_label} Acquisition')
+		pacq = model.Acquisition(ident='', label=f'{modifier_label} Acquisition')
 	pacq.transferred_title_of = hmo
 	if buyer:
 		pacq.transferred_title_to = buyer

--- a/pipeline/projects/provenance/__init__.py
+++ b/pipeline/projects/provenance/__init__.py
@@ -782,7 +782,7 @@ def related_procurement(current_tx, hmo, current_ts=None, buyer=None, seller=Non
 	and if the timespan `current_ts` is given, has temporal data to that effect. If
 	`previous` is `False`, this relationship is reversed.
 	'''
-	tx = vocab.Procurement(ident='')
+	tx = vocab.Procurement()
 	if current_tx:
 		if previous:
 			tx.ends_before_the_start_of = current_tx

--- a/scripts/remove_meaningless_ids.py
+++ b/scripts/remove_meaningless_ids.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3 -B
+
+import os
+import sys
+import json
+import uuid
+import pprint
+import itertools
+from pathlib import Path
+from contextlib import suppress
+
+from settings import output_file_path
+from pipeline.util.rewriting import rewrite_output_files, JSONValueRewriter
+from pipeline.projects.provenance.util import prev_post_sales_rewrite_map
+
+class JSONIDRemovalRewriter:
+	def __init__(self):
+		self.paths = {
+			'HumanMadeObject': [
+				('produced_by', 'id'),
+				('produced_by', 'part', 'id'),
+				('destroyed_by', 'id'),
+			]
+		}
+
+	def remove_path(self, data, path):
+		if len(path) == 1:
+			prop = path[0]
+			with suppress(KeyError):
+				del data[prop]
+		else:
+			head, *tail = path
+			if head in data:
+				child = data[head]
+				if isinstance(child, list):
+					for element in child:
+						self.remove_path(element, tail)
+				else:
+					self.remove_path(child, tail)
+
+	def rewrite(self, d, *args, file=None, **kwargs):
+		try:
+			type = d['type']
+		except KeyError:
+			return d
+		
+		if type in self.paths:
+			data = json.loads(json.dumps(d))
+			paths = self.paths[type]
+			for path in paths:
+				self.remove_path(data, path)
+			return data
+		else:
+			return d
+
+print(f'Removing meaningless `id` properties ...')
+r = JSONIDRemovalRewriter()
+rewrite_output_files(r, parallel=True)
+print('Done')


### PR DESCRIPTION
Some URIs are included during the pipeline and early post-processing to facilitate merging of records (e.g. objects that are merged as a result of previous sales data). However, only `id` fields should only stay in the JSON-LD files if they are top-level, or used to identify other top-level resources. This adds a post-processing step to remove `id` fields that do not fall into these categories.