### PR TITLE
Fix overly verbose output in scripts/reorganize_json.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,9 @@ pirdata:
 	PYTHONPATH=`pwd` $(PYTHON) ./scripts/rewrite_uris_to_uuids.py 'tag:getty.edu,2019:digital:pipeline:provenance:REPLACE-WITH-UUID#' "${GETTY_PIPELINE_TMP_PATH}/uri_to_uuid_map.json"
 	ls $(GETTY_PIPELINE_OUTPUT) | PYTHONPATH=`pwd` xargs -n 1 -P 8 -I '{}' $(PYTHON) ./scripts/coalesce_json.py "${GETTY_PIPELINE_OUTPUT}/{}"
 	PYTHONPATH=`pwd` $(PYTHON) ./scripts/remove_meaningless_ids.py
+	# Reorganizing JSON files...
 	find $(GETTY_PIPELINE_OUTPUT) -name '*.json' | PYTHONPATH=`pwd` xargs -n 256 -P 16 $(PYTHON) ./scripts/reorganize_json.py
+	# Done
 	find $(GETTY_PIPELINE_OUTPUT) -type d -empty -delete
 
 jsonlist:

--- a/scripts/reorganize_json.py
+++ b/scripts/reorganize_json.py
@@ -23,7 +23,9 @@ if len(sys.argv) > 1:
 else:
 	files = sorted(Path(output_file_path).rglob('*.json'))
 
-print('Reorganizing JSON files...')
+### This script avoids these status messages, because a normal pipeline run will invoke
+### this script thousands of times in parallel.
+# print('Reorganizing JSON files...')
 uuid_re = re.compile('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.json')
 for filename in files:
 	p = Path(filename)
@@ -41,4 +43,4 @@ for filename in files:
 	else:
 		pass
 # 		print(f'Already in the correct directory: {p}')
-print('Done')
+# print('Done')


### PR DESCRIPTION
The status output I added to one of the scripts last week was a bad idea, because it is called thousands of times in a normal pipeline run, so a simple `"Running"` or `"Done"` message ends up swamping the output.