### PR TITLE
Refactor sales pipeline

### DIFF
--- a/pipeline/projects/provenance/__init__.py
+++ b/pipeline/projects/provenance/__init__.py
@@ -42,24 +42,14 @@ from pipeline.projects import PipelineBase
 from pipeline.projects.provenance.util import *
 from pipeline.util import \
 			GraphListSource, \
-			truncate_with_ellipsis, \
 			CaseFoldingSet, \
 			RecursiveExtractKeyedValue, \
 			ExtractKeyedValue, \
 			ExtractKeyedValues, \
 			MatchingFiles, \
 			identity, \
-			implode_date, \
-			timespan_before, \
-			timespan_after, \
 			replace_key_pattern, \
-			strip_key_prefix, \
-			timespan_from_outer_bounds
-from pipeline.util.cleaners import \
-			parse_location, \
-			parse_location_name, \
-			date_parse, \
-			date_cleaner
+			strip_key_prefix
 from pipeline.io.file import MergingFileWriter
 from pipeline.io.memory import MergingMemoryWriter
 # from pipeline.io.arches import ArchesWriter
@@ -74,6 +64,10 @@ from pipeline.nodes.basic import \
 			Serializer, \
 			Trace
 from pipeline.util.rewriting import rewrite_output_files, JSONValueRewriter
+import pipeline.projects.provenance.events
+import pipeline.projects.provenance.lots
+import pipeline.projects.provenance.objects
+import pipeline.projects.provenance.catalogs
 
 #mark - utility functions and classes
 
@@ -84,7 +78,7 @@ class PersonIdentity:
 	def __init__(self, make_uri=None):
 		self.make_uri = make_uri or pir_uri
 		self.ignore_authnames = CaseFoldingSet(('NEW', 'NON-UNIQUE'))
-	
+
 	def acceptable_auth_name(self, auth_name):
 		if not auth_name or auth_name in self.ignore_authnames:
 			return False
@@ -92,7 +86,8 @@ class PersonIdentity:
 			return False
 		return True
 
-	def is_anonymous(self, data:dict):
+	@staticmethod
+	def is_anonymous(data:dict):
 		auth_name = data.get('auth_name')
 		if auth_name:
 			return '[ANONYMOUS' in auth_name
@@ -111,9 +106,8 @@ class PersonIdentity:
 
 		auth_name = data.get('auth_name')
 		auth_name_q = '?' in data.get('auth_nameq', '')
-	
+
 		if ulan:
-			key = f'PERSON-ULAN-{ulan}'
 			return ('PERSON', 'ULAN', ulan)
 		elif self.acceptable_auth_name(auth_name):
 			return ('PERSON', 'AUTHNAME', auth_name)
@@ -135,7 +129,7 @@ class PersonIdentity:
 		Based on the presence of `auth_name` and/or `name` fields in `data`, sets the
 		`label`, `names`, and `identifier` keys to appropriate strings/`model.Identifier`
 		values.
-		
+
 		If the `role` string is given (e.g. 'artist'), also sets the `role_label` key
 		to a value (e.g. 'artist “RUBENS, PETER PAUL”').
 		'''
@@ -179,6 +173,8 @@ class ProvenanceUtilityHelper:
 		self.ignore_house_authnames = CaseFoldingSet(('Anonymous',))
 		self.csv_source_columns = ['pi_record_no', 'catalog_number']
 		self.problematic_record_uri = 'tag:getty.edu,2019:digital:pipeline:provenance:ProblematicRecord'
+		self.person_identity = PersonIdentity()
+		self.uid_tag_prefix = UID_TAG_PREFIX
 
 	def copy_source_information(self, dst: dict, src: dict):
 		for k in self.csv_source_columns:
@@ -186,7 +182,8 @@ class ProvenanceUtilityHelper:
 				dst[k] = src[k]
 		return dst
 
-	def auction_event_for_catalog_number(self, catalog_number):
+	@staticmethod
+	def auction_event_for_catalog_number(catalog_number):
 		'''
 		Return a `vocab.AuctionEvent` object and its associated 'uid' key and URI, based on
 		the supplied `catalog_number`.
@@ -261,310 +258,6 @@ class ProvenanceUtilityHelper:
 				return True
 		return False
 
-class AddAuctionEvent(Configurable):
-	helper = Option(required=True)
-	
-	def __call__(self, data:dict):
-		'''Add modeling for an auction event based on properties of the supplied `data` dict.'''
-		cno = data['catalog_number']
-		auction, uid, uri = self.helper.auction_event_for_catalog_number(cno)
-		data['uid'] = uid
-		data['uri'] = uri
-		add_crom_data(data=data, what=auction)
-		catalog = get_crom_object(data['_catalog'])
-
-		record_uri = pir_uri('AUCTION-EVENT', 'CATALOGNUMBER', cno, 'RECORD')
-		label = f'Record of auction event from catalog {cno}'
-		record = model.LinguisticObject(ident=record_uri, label=label) # TODO: needs classification
-		record_data	= {'uri': record_uri}
-		record_data['identifiers'] = [model.Name(ident='', content=label)]
-		record.part_of = catalog
-
-		data['_record'] = add_crom_data(data=record_data, what=record)
-		return data
-
-#mark - Auction Events
-
-class PopulateAuctionEvent(Configurable):
-	auction_locations = Service('auction_locations')
-
-	def auction_event_location(self, data:dict):
-		'''
-		Based on location data in the supplied `data` dict, construct a data structure
-		representing a hierarchy of places (e.g. location->city->country), and return it.
-
-		This structure will be suitable for passing to `pipeline.linkedart.make_la_place`
-		to construct a Place model object.
-		'''
-		specific_name = data.get('specific_loc')
-		city_name = data.get('city_of_sale')
-		country_name = data.get('country_auth')
-
-		parts = [v for v in (specific_name, city_name, country_name) if v is not None]
-		loc = parse_location(*parts, uri_base=UID_TAG_PREFIX, types=('Place', 'City', 'Country'))
-		return loc
-
-	def __call__(self, data:dict, auction_locations):
-		'''Add modeling data for an auction event'''
-		cno = data['catalog_number']
-		auction = get_crom_object(data)
-		catalog = data['_catalog']['_LOD_OBJECT']
-
-		location_data = data['location']
-		current = self.auction_event_location(location_data)
-
-		# make_la_place is called here instead of as a separate graph node because the Place object
-		# gets stored in the `auction_locations` object to be used in the second graph component
-		# which uses the data to associate the place with auction lots.
-		base_uri = pir_uri('AUCTION-EVENT', 'CATALOGNUMBER', cno, 'PLACE')
-		place_data = pipeline.linkedart.make_la_place(current, base_uri=base_uri)
-		place = get_crom_object(place_data)
-		if place:
-			data['_locations'] = [place_data]
-			auction.took_place_at = place
-			auction_locations[cno] = place
-
-		begin = implode_date(data, 'sale_begin_', clamp='begin')
-		end = implode_date(data, 'sale_end_', clamp='eoe')
-		ts = timespan_from_outer_bounds(
-			begin=begin,
-			end=end,
-			inclusive=True
-		)
-		if begin and end:
-			ts.identified_by = model.Name(ident='', content=f'{begin} to {end}')
-		elif begin:
-			ts.identified_by = model.Name(ident='', content=f'{begin} onwards')
-		elif end:
-			ts.identified_by = model.Name(ident='', content=f'up to {end}')
-
-		for p in data.get('portal', []):
-			url = p['portal_url']
-			if url.startswith('http'):
-				auction.referred_to_by = vocab.WebPage(ident=url)
-			else:
-				warnings.warn(f'*** Portal URL value does not appear to be a valid URL: {url}')
-
-		if ts:
-			auction.timespan = ts
-
-		auction.referred_to_by = catalog
-		return data
-
-class AddAuctionHouses(Configurable):
-	helper = Option(required=True)
-	auction_houses = Service('auction_houses')
-	
-	def add_auction_house_data(self, a, event_record):
-		'''Add modeling data for an auction house organization.'''
-		catalog = a.get('_catalog')
-
-		ulan = None
-		with suppress(ValueError, TypeError):
-			ulan = int(a.get('auc_house_ulan'))
-		auth_name = a.get('auc_house_auth')
-		a['identifiers'] = []
-		if ulan:
-			key = f'AUCTION-HOUSE-ULAN-{ulan}'
-			a['uid'] = key
-			a['uri'] = pir_uri('AUCTION-HOUSE', 'ULAN', ulan)
-			a['ulan'] = ulan
-			house = vocab.AuctionHouseOrg(ident=a['uri'])
-		elif auth_name and auth_name not in self.helper.ignore_house_authnames:
-			a['uri'] = pir_uri('AUCTION-HOUSE', 'AUTHNAME', auth_name)
-			pname = vocab.PrimaryName(ident='', content=auth_name)
-			pname.referred_to_by = event_record
-			a['identifiers'].append(pname)
-			house = vocab.AuctionHouseOrg(ident=a['uri'])
-		else:
-			# not enough information to identify this house uniquely, so use the source location in the input file
-			a['uri'] = pir_uri('AUCTION-HOUSE', 'CAT_NO', 'CATALOG-NUMBER', a['catalog_number'])
-			house = vocab.AuctionHouseOrg(ident=a['uri'])
-
-		name = a.get('auc_house_name') or a.get('name')
-		if name:
-			n = model.Name(ident='', content=name)
-			n.referred_to_by = event_record
-			a['identifiers'].append(n)
-			a['label'] = name
-		else:
-			a['label'] = '(Anonymous)'
-
-		add_crom_data(data=a, what=house)
-		return a
-
-	def __call__(self, data:dict, auction_houses):
-		'''
-		Add modeling data for the auction house organization(s) associated with an auction
-		event.
-		'''
-		auction = get_crom_object(data)
-		event_record = get_crom_object(data['_record'])
-		catalog = data['_catalog']['_LOD_OBJECT']
-		d = data.copy()
-		houses = data.get('auction_house', [])
-		cno = data['catalog_number']
-
-		house_objects = []
-		event_record = get_crom_object(data['_record'])
-		for h in houses:
-			h['_catalog'] = catalog
-			self.add_auction_house_data(self.helper.copy_source_information(h, data), event_record)
-			house = get_crom_object(h)
-			auction.carried_out_by = house
-			if auction_houses:
-				house_objects.append(house)
-		auction_houses[cno] = house_objects
-		return d
-
-#mark - Auction of Lot
-
-class AddAuctionOfLot(Configurable):
-	'''Add modeling data for the auction of a lot of objects.'''
-
-	helper = Option(required=True)
-	problematic_records = Service('problematic_records')
-	auction_locations = Service('auction_locations')
-	auction_houses = Service('auction_houses')
-	non_auctions = Service('non_auctions')
-	def __init__(self, *args, **kwargs):
-		self.lot_cache = {}
-		super().__init__(*args, **kwargs)
-
-	@staticmethod
-	def set_lot_auction_houses(lot, cno, auction_houses):
-		'''Associate the auction house with the auction lot.'''
-		houses = auction_houses.get(cno)
-		if houses:
-			for house in houses:
-				lot.carried_out_by = house
-
-	@staticmethod
-	def set_lot_location(lot, cno, auction_locations):
-		'''Associate the location with the auction lot.'''
-		place = auction_locations.get(cno)
-		if place:
-			lot.took_place_at = place
-
-	@staticmethod
-	def set_lot_date(lot, auction_data):
-		'''Associate a timespan with the auction lot.'''
-		date = implode_date(auction_data, 'lot_sale_')
-# 		dates = date_parse(date, delim='-')
-# 		if dates:
-		if date:
-			begin = implode_date(auction_data, 'lot_sale_', clamp='begin')
-			end = implode_date(auction_data, 'lot_sale_', clamp='eoe')
-			bounds = [begin, end]
-		else:
-			bounds = []
-		if bounds:
-			ts = timespan_from_outer_bounds(*bounds)
-			ts.identified_by = model.Name(ident='', content=date)
-			lot.timespan = ts
-
-	def set_lot_notes(self, lot, auction_data):
-		'''Associate notes with the auction lot.'''
-		cno, lno, _ = object_key(auction_data)
-		auction, _, _ = self.helper.auction_event_for_catalog_number(cno)
-		notes = auction_data.get('lot_notes')
-		if notes:
-			note_id = lot.id + '-LotNotes'
-			lot.referred_to_by = vocab.Note(ident=note_id, content=notes)
-		if not lno:
-			warnings.warn(f'Setting empty identifier on {lot.id}')
-		lno = str(lno)
-		lot.identified_by = vocab.LotNumber(ident='', content=lno)
-		lot.part_of = auction
-
-	def set_lot_objects(self, lot, cno, lno, data):
-		'''Associate the set of objects with the auction lot.'''
-		coll = vocab.AuctionLotSet(ident=f'{data["uri"]}-Set')
-		shared_lot_number = self.helper.shared_lot_number_from_lno(lno)
-		coll._label = f'Auction Lot {cno} {shared_lot_number}'
-		est_price = data.get('estimated_price')
-		if est_price:
-			coll.dimension = get_crom_object(est_price)
-		start_price = data.get('start_price')
-		if start_price:
-			coll.dimension = get_crom_object(start_price)
-
-		lot.used_specific_object = coll
-		data['_lot_object_set'] = add_crom_data(data={}, what=coll)
-
-	def __call__(self, data, non_auctions, auction_houses, auction_locations, problematic_records):
-		'''Add modeling data for the auction of a lot of objects.'''
-		ask_price = data.get('ask_price', {}).get('ask_price')
-		if ask_price:
-			# if there is an asking price/currency, it's a direct sale, not an auction;
-			# filter these out from subsequent modeling of auction lots.
-			return
-
-		self.helper.copy_source_information(data['_object'], data)
-
-		auction_data = data['auction_of_lot']
-		try:
-			lot_object_key = object_key(auction_data)
-		except Exception as e:
-			warnings.warn(f'Failed to compute lot object key from data {auction_data} ({e})')
-			pprint.pprint({k: v for k, v in data.items() if v != ''})
-			raise
-		cno, lno, date = lot_object_key
-		if cno in non_auctions:
-			# the records in this sales catalog do not represent auction sales, so should
-			# be skipped.
-			return
-
-		shared_lot_number = self.helper.shared_lot_number_from_lno(lno)
-		uid, uri = self.helper.shared_lot_number_ids(cno, lno, date)
-		data['uid'] = uid
-		data['uri'] = uri
-
-		lot = vocab.Auction(ident=data['uri'])
-		lot_id = f'{cno} {shared_lot_number} ({date})'
-		lot_object_id = f'{cno} {lno} ({date})'
-		lot_label = f'Auction of Lot {lot_id}'
-		lot._label = lot_label
-		data['lot_id'] = lot_id
-		data['lot_object_id'] = lot_object_id
-
-		for problem_key, problem in problematic_records.get('lots', []):
-			# TODO: this is inefficient, but will probably be OK so long as the number
-			#       of problematic records is small. We do it this way because we can't
-			#       represent a tuple directly as a JSON dict key, and we don't want to
-			#       have to do post-processing on the services JSON files after loading.
-			if tuple(problem_key) == lot_object_key:
-				note = model.LinguisticObject(ident='', content=problem)
-				note.classified_as = vocab.instances["brief text"]
-				note.classified_as = model.Type(
-					ident=self.helper.problematic_record_uri,
-					label='Problematic Record'
-				)
-				lot.referred_to_by = note
-
-		self.set_lot_auction_houses(lot, cno, auction_houses)
-		self.set_lot_location(lot, cno, auction_locations)
-		self.set_lot_date(lot, auction_data)
-		self.set_lot_notes(lot, auction_data)
-		self.set_lot_objects(lot, cno, lno, data)
-
-		tx_uri = self.helper.transaction_uri_for_lot(auction_data, data.get('price', []))
-		lots = self.helper.lots_in_transaction(auction_data, data.get('price', []))
-		multi = self.helper.transaction_contains_multiple_lots(auction_data, data.get('price', []))
-		tx = vocab.Procurement(ident=tx_uri)
-		tx._label = f'Procurement of Lot {cno} {lots} ({date})'
-		lot.caused = tx
-		tx_data = {'uri': tx_uri}
-
-		if multi:
-			tx_data['multi_lot_tx'] = lots
-		with suppress(AttributeError):
-			tx_data['_date'] = lot.timespan
-		data['_procurement_data'] = add_crom_data(data=tx_data, what=tx)
-
-		add_crom_data(data=data, what=lot)
-		yield data
-
 def add_crom_price(data, parent, services):
 	'''
 	Add modeling data for `MonetaryAmount`, `StartingPrice`, or `EstimatedPrice`,
@@ -584,333 +277,6 @@ def add_crom_price(data, parent, services):
 		add_crom_data(data=data, what=amnt)
 	return data
 
-class AddAcquisitionOrBidding(Configurable):
-	helper = Option(required=True)
-	buy_sell_modifiers = Service('buy_sell_modifiers')
-	make_la_person = Service('make_la_person')
-
-	def related_procurement(self, current_tx, hmo, current_ts=None, buyer=None, seller=None, previous=False):
-		'''
-		Returns a new `vocab.Procurement` object (and related acquisition) that is temporally
-		related to the supplied procurement and associated data. The new procurement is for
-		the given object, and has the given buyer and seller (both optional).
-
-		If the `previous` flag is `True`, the new procurement is occurs before `current_tx`,
-		and if the timespan `current_ts` is given, has temporal data to that effect. If
-		`previous` is `False`, this relationship is reversed.
-		'''
-		tx = vocab.Procurement()
-		if current_tx:
-			if previous:
-				tx.ends_before_the_start_of = current_tx
-			else:
-				tx.starts_after_the_end_of = current_tx
-		modifier_label = 'Previous' if previous else 'Subsequent'
-		try:
-			pacq = model.Acquisition(ident='', label=f'{modifier_label} Acquisition of: “{hmo._label}”')
-		except AttributeError:
-			pacq = model.Acquisition(ident='', label=f'{modifier_label} Acquisition')
-		pacq.transferred_title_of = hmo
-		if buyer:
-			pacq.transferred_title_to = buyer
-		if seller:
-			pacq.transferred_title_from = seller
-		tx.part = pacq
-		if current_ts:
-			if previous:
-				pacq.timespan = timespan_before(current_ts)
-			else:
-				pacq.timespan = timespan_after(current_ts)
-		return tx
-
-	def final_owner_procurement(self, final_owner, current_tx, hmo, current_ts):
-		tx = self.related_procurement(current_tx, hmo, current_ts, buyer=final_owner)
-		try:
-			object_label = hmo._label
-			tx._label = f'Procurement leading to the currently known location of “{object_label}”'
-		except AttributeError:
-			tx._label = f'Procurement leading to the currently known location of object'
-		return tx
-
-	def add_acquisition(self, data, buyers, sellers, buy_sell_modifiers, make_la_person=None):
-		'''Add modeling of an acquisition as a transfer of title from the seller to the buyer'''
-		sales_record = get_crom_object(data['_record'])
-		hmo = get_crom_object(data)
-		parent = data['parent_data']
-	# 	transaction = parent['transaction']
-		prices = parent['price']
-		auction_data = parent['auction_of_lot']
-		cno, lno, date = object_key(auction_data)
-		data['buyer'] = buyers
-		data['seller'] = sellers
-	
-		acq_label = None
-		try:
-			object_label = f'“{hmo._label}”'
-			acq_label = f'Acquisition of {cno} {lno} ({date}): {object_label}'
-		except AttributeError:
-			object_label = '(object)'
-			acq_label = f'Acquisition of {cno} {lno} ({date})'
-		amnts = [get_crom_object(p) for p in prices]
-
-	# 	if not prices:
-	# 		print(f'*** No price data found for {transaction} transaction')
-
-		tx_data = parent['_procurement_data']
-		current_tx = get_crom_object(tx_data)
-		payment_id = current_tx.id + '-Payment'
-
-		acq_id = hmo.id + '-Acquisition'
-		acq = model.Acquisition(ident=acq_id, label=acq_label)
-		acq.transferred_title_of = hmo
-
-		multi = tx_data.get('multi_lot_tx')
-		paym_label = f'multiple lots {multi}' if multi else object_label
-		paym = model.Payment(ident=payment_id, label=f'Payment for {paym_label}')
-
-		THROUGH = set(buy_sell_modifiers['through'])
-		FOR = set(buy_sell_modifiers['for'])
-
-		for seller_data in sellers:
-			seller = get_crom_object(seller_data)
-			mod = seller_data.get('auth_mod_a', '')
-
-			if 'or' == mod:
-				mod_non_auth = seller_data.get('auth_mod')
-				if mod_non_auth:
-					acq.referred_to_by = vocab.Note(ident='', label=f'Seller modifier', content=mod_non_auth)
-				warnings.warn('Handle OR buyer modifier') # TODO: some way to model this uncertainty?
-
-			if mod in THROUGH:
-				acq.carried_out_by = seller
-				paym.carried_out_by = seller
-			elif mod in FOR:
-				acq.transferred_title_from = seller
-				paym.paid_to = seller
-			else:
-				# covers non-modified
-				acq.carried_out_by = seller
-				acq.transferred_title_from = seller
-				paym.carried_out_by = seller
-				paym.paid_to = seller
-
-		for buyer_data in buyers:
-			buyer = get_crom_object(buyer_data)
-			mod = buyer_data.get('auth_mod_a', '')
-		
-			if 'or' == mod:
-				# or/or others/or another
-				mod_non_auth = buyer_data.get('auth_mod')
-				if mod_non_auth:
-					acq.referred_to_by = vocab.Note(ident='', label=f'Buyer modifier', content=mod_non_auth)
-				warnings.warn(f'Handle buyer modifier: {mod}') # TODO: some way to model this uncertainty?
-
-			if mod in THROUGH:
-				acq.carried_out_by = buyer
-				paym.carried_out_by = buyer
-			elif mod in FOR:
-				acq.transferred_title_to = buyer
-				paym.paid_from = buyer
-			else:
-				# covers non-modified
-				acq.carried_out_by = buyer
-				acq.transferred_title_to = buyer
-				paym.carried_out_by = buyer
-				paym.paid_from = buyer
-
-		if len(amnts) > 1:
-			warnings.warn(f'Multiple Payment.paid_amount values for object {hmo.id} ({payment_id})')
-		for amnt in amnts:
-			paym.paid_amount = amnt
-			break # TODO: sensibly handle multiplicity in paid amount data
-
-		ts = tx_data.get('_date')
-		if ts:
-			acq.timespan = ts
-		current_tx.part = paym
-		current_tx.part = acq
-		if '_procurements' not in data:
-			data['_procurements'] = []
-		data['_procurements'] += [add_crom_data(data={}, what=current_tx)]
-	# 	lot_uid, lot_uri = helper.shared_lot_number_ids(cno, lno)
-		# TODO: `annotation` here is from add_physical_catalog_objects
-	# 	paym.referred_to_by = annotation
-
-		data['_acquisition'] = add_crom_data(data={'uri': acq_id}, what=acq)
-
-		final_owner_data = data.get('_final_org', [])
-		if final_owner_data:
-			data['_organizations'].append(final_owner_data)
-			final_owner = get_crom_object(final_owner_data)
-			tx = self.final_owner_procurement(final_owner, current_tx, hmo, ts)
-			data['_procurements'].append(add_crom_data(data={}, what=tx))
-
-		post_own = data.get('post_owner', [])
-		prev_own = data.get('prev_owner', [])
-		prev_post_owner_records = [(post_own, False), (prev_own, True)]
-		for owner_data, rev in prev_post_owner_records:
-			if rev:
-				rev_name = 'prev-owner'
-				source_label = 'Source of information on history of the object prior to the current sale.'
-			else:
-				rev_name = 'post-owner'
-				source_label = 'Source of information on history of the object after the current sale.'
-			for seq_no, owner_record in enumerate(owner_data):
-				ignore_fields = ('own_so', 'own_auth_l', 'own_auth_d')
-				if not any([bool(owner_record.get(k)) for k in owner_record.keys() if k not in ignore_fields]):
-					# some records seem to have metadata (source information, location, or notes) but no other fields set
-					# these should not constitute actual records of a prev/post owner.
-					continue
-				owner_record.update({
-					'pi_record_no': data['pi_record_no'],
-					'ulan': owner_record['own_ulan'],
-					'auth_name': owner_record['own_auth'],
-					'name': owner_record['own']
-				})
-				pi = PersonIdentity()
-				pi.add_uri(owner_record, record_id=f'{rev_name}-{seq_no+1}')
-				pi.add_names(owner_record, referrer=sales_record, role='artist')
-				make_la_person(owner_record)
-				owner = get_crom_object(owner_record)
-			
-				# TODO: handle other fields of owner_record: own_auth_d, own_auth_q, own_ques, own_so
-			
-				if owner_record.get('own_auth_l'):
-					loc = owner_record['own_auth_l']
-					current = parse_location_name(loc, uri_base=UID_TAG_PREFIX)
-					place_data = pipeline.linkedart.make_la_place(current)
-					place = get_crom_object(place_data)
-					owner.residence = place
-					data['_owner_locations'].append(place_data)
-			
-				if '_other_owners' not in data:
-					data['_other_owners'] = []
-				data['_other_owners'].append(owner_record)
-
-				tx = self.related_procurement(current_tx, hmo, ts, buyer=owner, previous=rev)
-
-				own_info_source = owner_record.get('own_so')
-				if own_info_source:
-					note = vocab.SourceStatement(ident='', content=own_info_source, label=source_label)
-					tx.referred_to_by = note
-
-				ptx_data = tx_data.copy()
-				data['_procurements'].append(add_crom_data(data=ptx_data, what=tx))
-		yield data
-
-	def add_bidding(self, data:dict, buyers, buy_sell_modifiers):
-		'''Add modeling of bids that did not lead to an acquisition'''
-		parent = data['parent_data']
-		prices = parent['price']
-		amnts = [get_crom_object(p) for p in prices]
-
-		if amnts:
-			auction_data = parent['auction_of_lot']
-			cno, lno, date = object_key(auction_data)
-			lot = get_crom_object(parent)
-			hmo = get_crom_object(data)
-			bidding_id = hmo.id + '-Bidding'
-			all_bids = model.Activity(ident=bidding_id, label=f'Bidding on {cno} {lno} ({date})')
-
-			all_bids.part_of = lot
-
-			THROUGH = set(buy_sell_modifiers['through'])
-			FOR = set(buy_sell_modifiers['for'])
-
-			for seq_no, amnt in enumerate(amnts):
-				bid_id = hmo.id + f'-Bid-{seq_no}'
-				bid = vocab.Bidding(ident=bid_id)
-				prop_id = hmo.id + f'-Bid-{seq_no}-Promise'
-				try:
-					amnt_label = amnt._label
-					bid._label = f'Bid of {amnt_label} on {cno} {lno} ({date})'
-					prop = model.PropositionalObject(ident=prop_id, label=f'Promise to pay {amnt_label}')
-				except AttributeError:
-					bid._label = f'Bid on {cno} {lno} ({date})'
-					prop = model.PropositionalObject(ident=prop_id, label=f'Promise to pay')
-
-				prop.refers_to = amnt
-				bid.created = prop
-
-				# TODO: there are often no buyers listed for non-sold records.
-				#       should we construct an anonymous person to carry out the bid?
-				for buyer_data in buyers:
-					buyer = get_crom_object(buyer_data)
-					mod = buyer_data.get('auth_mod_a', '')
-					if mod in THROUGH:
-						bid.carried_out_by = buyer
-					elif mod in FOR:
-						warnings.warn(f'buyer modifier {mod} for non-sale bidding: {cno} {lno} {date}')
-						pass
-					else:
-						bid.carried_out_by = buyer
-
-				all_bids.part = bid
-
-			final_owner_data = data.get('_final_org')
-			if final_owner_data:
-				data['_organizations'].append(final_owner_data)
-				final_owner = get_crom_object(final_owner_data)
-				ts = lot.timespan
-				hmo = get_crom_object(data)
-				tx = self.final_owner_procurement(final_owner, None, hmo, ts)
-				if '_procurements' not in data:
-					data['_procurements'] = []
-				data['_procurements'].append(add_crom_data(data={}, what=tx))
-
-			data['_bidding'] = {'uri': bidding_id}
-			add_crom_data(data=data['_bidding'], what=all_bids)
-			yield data
-		else:
-			warnings.warn(f'*** No price data found for {parent["transaction"]!r} transaction')
-			yield data
-
-	def add_person(self, data:dict, sales_record, rec_id, *, make_la_person):
-		'''
-		Add modeling data for people, based on properties of the supplied `data` dict.
-
-		This function adds properties to `data` before calling
-		`pipeline.linkedart.MakeLinkedArtPerson` to construct the model objects.
-		'''
-		pi = PersonIdentity()
-		pi.add_uri(data, record_id=rec_id)
-		pi.add_names(data, referrer=sales_record)
-
-		make_la_person(data)
-		return data
-
-	def __call__(self, data:dict, buy_sell_modifiers, make_la_person):
-		'''Determine if this record has an acquisition or bidding, and add appropriate modeling'''
-		parent = data['parent_data']
-		sales_record = get_crom_object(data['_record'])
-		transaction = parent['transaction']
-		transaction = transaction.replace('[?]', '').rstrip()
-
-		buyers = [
-			self.add_person(
-				self.helper.copy_source_information(p, parent),
-				sales_record,
-				f'buyer_{i+1}',
-				make_la_person=make_la_person
-			) for i, p in enumerate(parent['buyer'])
-		]
-
-		# TODO: is this the right set of transaction types to represent acquisition?
-		if transaction in ('Sold', 'Vendu', 'Verkauft', 'Bought In'):
-			sellers = [
-				self.add_person(
-					self.helper.copy_source_information(p, parent),
-					sales_record,
-					f'seller_{i+1}',
-					make_la_person=make_la_person
-				) for i, p in enumerate(parent['seller'])
-			]
-			data['_owner_locations'] = []
-			yield from self.add_acquisition(data, buyers, sellers, buy_sell_modifiers, make_la_person)
-		elif transaction in ('Unknown', 'Unbekannt', 'Inconnue', 'Withdrawn', 'Non Vendu', ''):
-			yield from self.add_bidding(data, buyers, buy_sell_modifiers)
-		else:
-			warnings.warn(f'Cannot create acquisition data for unknown transaction type: {transaction!r}')
 
 #mark - Single Object Lot Tracking
 
@@ -924,593 +290,6 @@ class TrackLotSizes(Configurable):
 		lot = self.helper.shared_lot_number_from_lno(lno)
 		key = (cno, lot, date)
 		lot_counter[key] += 1
-
-#mark - Auction of Lot - Physical Object
-
-class PopulateObject(Configurable):
-	helper = Option(required=True)
-	post_sale_map = Service('post_sale_map')
-	unique_catalogs = Service('unique_catalogs')
-	vocab_instance_map = Service('vocab_instance_map')
-	destruction_types_map = Service('destruction_types_map')
-
-	def genre_instance(self, value, vocab_instance_map):
-		'''Return the appropriate type instance for the supplied genre name'''
-		if value is None:
-			return None
-		value = value.lower()
-
-		instance_name = vocab_instance_map.get(value)
-		if instance_name:
-			instance = vocab.instances.get(instance_name)
-			if not instance:
-				warnings.warn(f'*** No genre instance available for {instance_name!r} in vocab_instance_map')
-			return instance
-		return None
-
-	def populate_destruction_events(self, data:dict, note, *, type_map, location=None):
-		destruction_types_map = type_map
-		hmo = get_crom_object(data)
-		title = data.get('title')
-		short_title = truncate_with_ellipsis(title, 100) or title
-
-		r = re.compile(r'[Dd]estroyed(?: (?:by|during) (\w+))?(?: in (\d{4})[.]?)?')
-		m = r.search(note)
-		if m:
-			method = m.group(1)
-			year = m.group(2)
-			dest_id = hmo.id + '-Destruction'
-			d = model.Destruction(ident=dest_id, label=f'Destruction of “{short_title}”')
-			d.referred_to_by = vocab.Note(ident='', content=note)
-			if year is not None:
-				begin, end = date_cleaner(year)
-				ts = timespan_from_outer_bounds(begin, end)
-				ts.identified_by = model.Name(ident='', content=year)
-				d.timespan = ts
-
-			if method:
-				with suppress(KeyError, AttributeError):
-					type_name = destruction_types_map[method.lower()]
-					type = vocab.instances[type_name]
-					event = model.Event(label=f'{method.capitalize()} event causing the destruction of “{short_title}”')
-					event.classified_as = type
-					d.caused_by = event
-					data['_events'].append(add_crom_data(data={}, what=event))
-
-			if location:
-				current = parse_location_name(location, uri_base=UID_TAG_PREFIX)
-				base_uri = hmo.id + '-Place,'
-				place_data = pipeline.linkedart.make_la_place(current, base_uri=base_uri)
-				place = get_crom_object(place_data)
-				if place:
-					data['_locations'].append(place_data)
-					d.took_place_at = place
-
-			hmo.destroyed_by = d
-
-	def _populate_object_visual_item(self, data:dict, vocab_instance_map):
-		hmo = get_crom_object(data)
-		title = data.get('title')
-		title = truncate_with_ellipsis(title, 100) or title
-
-		vi_id = hmo.id + '-VisualItem'
-		vi = model.VisualItem(ident=vi_id)
-		vidata = {'uri': vi_id}
-		if title:
-			vidata['label'] = f'Visual work of “{title}”'
-			sales_record = get_crom_object(data['_record'])
-			vidata['names'] = [(title,{'referred_to_by': [sales_record]})]
-
-		genre = self.genre_instance(data.get('genre'), vocab_instance_map)
-		if genre:
-			vi.classified_as = genre
-		data['_visual_item'] = add_crom_data(data=vidata, what=vi)
-		hmo.shows = vi
-
-	def _populate_object_catalog_record(self, data:dict, parent, lot, cno, rec_num):
-		catalog_uri = pir_uri('CATALOG', cno)
-		catalog = vocab.AuctionCatalogText(ident=catalog_uri)
-	
-		record_uri = pir_uri('CATALOG', cno, 'RECORD', rec_num)
-		lot_object_id = parent['lot_object_id']
-		record = model.LinguisticObject(ident=record_uri, label=f'Sale recorded in catalog: {lot_object_id} (record number {rec_num})') # TODO: needs classification
-		record_data	= {'uri': record_uri}
-		record_data['identifiers'] = [model.Name(ident='', content=f'Record of sale {lot_object_id}')]
-		record.part_of = catalog
-
-		data['_record'] = add_crom_data(data=record_data, what=record)
-		return record
-
-	def _populate_object_destruction(self, data:dict, parent, destruction_types_map):
-		notes = parent.get('auction_of_lot', {}).get('lot_notes')
-		if notes and notes.lower().startswith('destroyed'):
-			self.populate_destruction_events(data, notes, type_map=destruction_types_map)
-
-	def _populate_object_statements(self, data:dict):
-		hmo = get_crom_object(data)
-		materials = data.get('materials')
-		if materials:
-			matstmt = vocab.MaterialStatement(ident='', content=materials)
-			sales_record = get_crom_object(data['_record'])
-			matstmt.referred_to_by = sales_record
-			hmo.referred_to_by = matstmt
-
-		dimstr = data.get('dimensions')
-		if dimstr:
-			dimstmt = vocab.DimensionStatement(ident='', content=dimstr)
-			sales_record = get_crom_object(data['_record'])
-			dimstmt.referred_to_by = sales_record
-			hmo.referred_to_by = dimstmt
-			for dim in extract_physical_dimensions(dimstr):
-				dim.referred_to_by = sales_record
-				hmo.dimension = dim
-		else:
-			pass
-	# 		print(f'No dimension data was parsed from the dimension statement: {dimstr}')
-
-	def _populate_object_present_location(self, data:dict, now_key, destruction_types_map):
-		hmo = get_crom_object(data)
-		location = data.get('present_location')
-		if location:
-			loc = location.get('geog')
-			note = location.get('note')
-			if loc:
-				if 'destroyed ' in loc.lower():
-					self.populate_destruction_events(data, loc, type_map=destruction_types_map)
-				elif isinstance(note, str) and 'destroyed ' in note.lower():
-					# the object was destroyed, so any "present location" data is actually
-					# an indication of the location of destruction.
-					self.populate_destruction_events(data, note, type_map=destruction_types_map, location=loc)
-				else:
-					# TODO: if `parse_location_name` fails, still preserve the location string somehow
-					current = parse_location_name(loc, uri_base=UID_TAG_PREFIX)
-					inst = location.get('inst')
-					if inst:
-						owner_data = {
-							'label': f'{inst} ({loc})',
-							'identifiers': [
-								model.Name(ident='', content=inst)
-							]
-						}
-						ulan = None
-						with suppress(ValueError, TypeError):
-							ulan = int(location.get('insi'))
-						if ulan:
-							owner_data['ulan'] = ulan
-							owner_data['uri'] = pir_uri('ORGANIZATION', 'ULAN', ulan)
-						else:
-							owner_data['uri'] = pir_uri('ORGANIZATION', 'NAME', inst, 'PLACE', loc)
-					else:
-						owner_data = {
-							'label': '(Anonymous organization)',
-							'uri': pir_uri('ORGANIZATION', 'PRESENT-OWNER', *now_key),
-						}
-
-					base_uri = hmo.id + '-Place,'
-					place_data = pipeline.linkedart.make_la_place(current, base_uri=base_uri)
-					place = get_crom_object(place_data)
-
-					make_la_org = pipeline.linkedart.MakeLinkedArtOrganization()
-					owner_data = make_la_org(owner_data)
-					owner = get_crom_object(owner_data)
-					owner.residence = place
-					data['_locations'].append(place_data)
-					data['_final_org'] = owner_data
-			else:
-				pass # there is no present location place string
-			if note:
-				pass
-				# TODO: the acquisition_note needs to be attached as a Note to the final post owner acquisition
-
-	def _populate_object_notes(self, data:dict, parent, unique_catalogs):
-		hmo = get_crom_object(data)
-		notes = data.get('hand_note', [])
-		for note in notes:
-			hand_note_content = note['hand_note']
-			owner = note.get('hand_note_so')
-			cno = parent['auction_of_lot']['catalog_number']
-			catalog_uri = pir_uri('CATALOG', cno, owner, None)
-			catalogs = unique_catalogs.get(catalog_uri)
-			note = vocab.Note(ident='', content=hand_note_content)
-			hmo.referred_to_by = note
-			if catalogs and len(catalogs) == 1:
-				note.carried_by = vocab.AuctionCatalog(ident=catalog_uri, label=f'Sale Catalog {cno}, owned by “{owner}”')
-
-		inscription = data.get('inscription')
-		if inscription:
-			hmo.referred_to_by = vocab.InscriptionStatement(ident='', content=inscription)
-
-	def _populate_object_prev_post_sales(self, data:dict, this_key, post_sale_map):
-		post_sales = data.get('post_sale', [])
-		prev_sales = data.get('prev_sale', [])
-		prev_post_sales_records = [(post_sales, False), (prev_sales, True)]
-		for sales_data, rev in prev_post_sales_records:
-			for sale_record in sales_data:
-				pcno = sale_record.get('cat')
-				plno = sale_record.get('lot')
-				plot = self.helper.shared_lot_number_from_lno(plno)
-				pdate = implode_date(sale_record, '')
-				if pcno and plot and pdate:
-					that_key = (pcno, plot, pdate)
-					if rev:
-						# `that_key` is for a previous sale for this object
-						post_sale_map[this_key] = that_key
-					else:
-						# `that_key` is for a later sale for this object
-						post_sale_map[that_key] = this_key
-
-	def __call__(self, data:dict, post_sale_map, unique_catalogs, vocab_instance_map, destruction_types_map):
-		'''Add modeling for an object described by a sales record'''
-		hmo = get_crom_object(data)
-		parent = data['parent_data']
-		auction_data = parent.get('auction_of_lot')
-		if auction_data:
-			lno = str(auction_data['lot_number'])
-			if 'identifiers' not in data:
-				data['identifiers'] = []
-			if not lno:
-				warnings.warn(f'Setting empty identifier on {hmo.id}')
-			data['identifiers'].append(vocab.LotNumber(ident='', content=lno))
-		else:
-			warnings.warn(f'***** NO AUCTION DATA FOUND IN populate_object')
-
-
-		cno = auction_data['catalog_number']
-		lno = auction_data['lot_number']
-		date = implode_date(auction_data, 'lot_sale_')
-		lot = self.helper.shared_lot_number_from_lno(lno)
-		now_key = (cno, lot, date) # the current key for this object; may be associated later with prev and post object keys
-
-		data['_locations'] = []
-		data['_events'] = []
-		record = self._populate_object_catalog_record(data, parent, lot, cno, parent['pi_record_no'])
-		self._populate_object_visual_item(data, vocab_instance_map)
-		self._populate_object_destruction(data, parent, destruction_types_map)
-		self._populate_object_statements(data)
-		self._populate_object_present_location(data, now_key, destruction_types_map)
-		self._populate_object_notes(data, parent, unique_catalogs)
-		self._populate_object_prev_post_sales(data, now_key, post_sale_map)
-		for p in data.get('portal', []):
-			url = p['portal_url']
-			hmo.referred_to_by = vocab.WebPage(ident=url)
-
-		if 'title' in data:
-			title = data['title']
-			if not hasattr(hmo, '_label'):
-				typestring = data.get('object_type', 'Object')
-				hmo._label = f'{typestring}: “{title}”'
-			del(data['title'])
-			shorter = truncate_with_ellipsis(title, 100)
-			if shorter:
-				description = vocab.Description(ident='', content=title)
-				description.referred_to_by = record
-				hmo.referred_to_by = description
-				title = shorter
-			t = vocab.PrimaryName(ident='', content=title)
-			t.classified_as = model.Type(ident='http://vocab.getty.edu/aat/300417193', label='Title')
-			t.referred_to_by = record
-			data['identifiers'].append(t)
-
-		return data
-
-@use('vocab_type_map')
-def add_object_type(data, vocab_type_map):
-	'''Add appropriate type information for an object based on its 'object_type' name'''
-	typestring = data.get('object_type', '')
-	if typestring in vocab_type_map:
-		clsname = vocab_type_map.get(typestring, None)
-		otype = getattr(vocab, clsname)
-		add_crom_data(data=data, what=otype(ident=data['uri']))
-	elif ';' in typestring:
-		parts = [s.strip() for s in typestring.split(';')]
-		if all([s in vocab_type_map for s in parts]):
-			types = [getattr(vocab, vocab_type_map[s]) for s in parts]
-			obj = vocab.make_multitype_obj(*types, ident=data['uri'])
-			add_crom_data(data=data, what=obj)
-		else:
-			warnings.warn(f'*** Not all object types matched for {typestring!r}')
-			add_crom_data(data=data, what=model.HumanMadeObject(ident=data['uri']))
-	else:
-		warnings.warn(f'*** No object type for {typestring!r}')
-		add_crom_data(data=data, what=model.HumanMadeObject(ident=data['uri']))
-
-	parent = data['parent_data']
-	coll_data = parent.get('_lot_object_set')
-	if coll_data:
-		coll = get_crom_object(coll_data)
-		if coll:
-			data['member_of'] = [coll]
-
-	return data
-
-class AddArtists(Configurable):
-	attribution_modifiers = Service('attribution_modifiers')
-	attribution_group_types = Service('attribution_group_types')
-	make_la_person = Service('make_la_person')
-	
-	def __call__(self, data:dict, *, attribution_modifiers, attribution_group_types, make_la_person):
-		'''Add modeling for artists as people involved in the production of an object'''
-		hmo = get_crom_object(data)
-		data['_organizations'] = []
-		data['_original_objects'] = []
-	
-		try:
-			hmo_label = f'{hmo._label}'
-		except AttributeError:
-			hmo_label = 'object'
-		event_id = hmo.id + '-Production'
-		event = model.Production(ident=event_id, label=f'Production event for {hmo_label}')
-		hmo.produced_by = event
-
-		artists = data.get('_artists', [])
-
-		sales_record = get_crom_object(data['_record'])
-		pi = PersonIdentity()
-	
-		for a in artists:
-			a.update({
-				'pi_record_no': data['pi_record_no'],
-				'ulan': a['artist_ulan'],
-				'auth_name': a['art_authority'],
-				'name': a['artist_name']
-			})
-
-		def is_or_anon(data:dict):
-			if not pi.is_anonymous(data):
-				return False
-			mods = {m.lower().strip() for m in data.get('attrib_mod_auth', '').split(';')}
-			return 'or' in mods
-		or_anon_records = [is_or_anon(a) for a in artists]
-		uncertain_attribution = any(or_anon_records)
-		for seq_no, a in enumerate(artists):
-			attrib_assignment_classes = [model.AttributeAssignment]
-			if uncertain_attribution:
-				attrib_assignment_classes.append(vocab.PossibleAssignment)
-			if is_or_anon(a):
-				# do not model the "or anonymous" records; they turn into uncertainty on the other records
-				continue
-			pi.add_uri(a, record_id=f'artist-{seq_no+1}')
-			pi.add_names(a, referrer=sales_record, role='artist')
-			artist_label = a.get('role_label')
-			make_la_person(a)
-			person = get_crom_object(a)
-		
-			mod = a.get('attrib_mod_auth')
-			if mod:
-				mods = {m.lower().strip() for m in mod.split(';')}
-			
-				# TODO: this should probably be in its own JSON service file:
-				STYLE_OF = set(attribution_modifiers['style of'])
-				FORMERLY_ATTRIBUTED_TO = set(attribution_modifiers['formerly attributed to'])
-				ATTRIBUTED_TO = set(attribution_modifiers['attributed to'])
-				COPY_AFTER = set(attribution_modifiers['copy after'])
-				PROBABLY = set(attribution_modifiers['probably by'])
-				POSSIBLY = set(attribution_modifiers['possibly by'])
-				UNCERTAIN = PROBABLY | POSSIBLY
-
-				GROUP_TYPES = set(attribution_group_types.values())
-				GROUP_MODS = {k for k, v in attribution_group_types.items() if v in GROUP_TYPES}
-			
-				if 'or' in mods:
-					warnings.warn('Handle OR attribution modifier') # TODO: some way to model this uncertainty?
-			
-				if 'copy by' in mods:
-					# equivalent to no modifier
-					pass
-				elif ATTRIBUTED_TO & mods:
-					# equivalent to no modifier
-					pass
-				elif STYLE_OF & mods:
-					assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'In the style of {artist_label}')
-					event.attributed_by = assignment
-					assignment.assigned_property = 'influenced_by'
-					assignment.property_classified_as = vocab.instances['style of']
-					assignment.assigned = person
-					continue
-				elif GROUP_MODS & mods:
-					mod_name = list(GROUP_MODS & mods)[0] # TODO: use all matching types?
-					clsname = attribution_group_types[mod_name]
-					cls = getattr(vocab, clsname)
-					style_prod_uri = event_id + f'-style-{seq_no}'
-					group_label = f'{clsname} of {artist_label}'
-					group_id = a['uri'] + f'-{clsname}'
-					group = cls(ident=group_id, label=group_label)
-					formation = model.Formation(ident='', label=f'Formation of {group_label}')
-					formation.influenced_by = person
-					group.formed_by = formation
-					group_data = add_crom_data({'uri': group_id}, group)
-					data['_organizations'].append(group_data)
-
-					subevent_id = event_id + f'-{seq_no}'
-					subevent = model.Production(ident=subevent_id, label=f'Production sub-event for {group_label}')
-					subevent.carried_out_by = group
-				
-					if uncertain_attribution:
-						assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'Possibly attributed to {group_label}')
-						event.attributed_by = assignment
-						assignment.assigned_property = 'part'
-						assignment.assigned = subevent
-					else:
-						event.part = subevent
-					continue
-				elif FORMERLY_ATTRIBUTED_TO & mods:
-					# the {uncertain_attribution} flag does not apply to this branch, because this branch is not making a statement
-					# about a previous attribution. the uncertainty applies only to the current attribution.
-					assignment = vocab.ObsoleteAssignment(ident='', label=f'Formerly attributed to {artist_label}')
-					event.attributed_by = assignment
-					assignment.assigned_property = 'carried_out_by'
-					assignment.assigned = person
-					continue
-				elif UNCERTAIN & mods:
-					if POSSIBLY & mods:
-						attrib_assignment_classes.append(vocab.PossibleAssignment)
-						assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'Possibly attributed to {artist_label}')
-						assignment._label = f'Possibly by {artist_label}'
-					else:
-						attrib_assignment_classes.append(vocab.ProbableAssignment)
-						assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'Probably attributed to {artist_label}')
-						assignment._label = f'Probably by {artist_label}'
-					event.attributed_by = assignment
-					assignment.assigned_property = 'carried_out_by'
-					assignment.assigned = person
-					continue
-				elif COPY_AFTER & mods:
-					# the {uncertain_attribution} flag does not apply to this branch, because this branch is not making a statement
-					# about the artist of the work, but about the artist of the original work that this work is a copy of.
-					cls = type(hmo)
-					original_id = hmo.id + '-Original'
-					original_label = f'Original of {hmo_label}'
-					original_hmo = cls(ident=original_id, label=original_label)
-					original_event_id = original_hmo.id + '-Production'
-					original_event = model.Production(ident=original_event_id, label=f'Production event for {original_label}')
-					original_hmo.produced_by = original_event
-
-					original_subevent_id = original_event_id + f'-{seq_no}'
-					original_subevent = model.Production(ident=original_subevent_id, label=f'Production sub-event for {artist_label}')
-					original_event.part = original_subevent
-					original_subevent.carried_out_by = person
-
-					event.influenced_by = original_hmo
-					data['_original_objects'].append(add_crom_data(data={}, what=original_hmo))
-					continue
-				elif {'or', 'and'} & mods:
-					pass
-				else:
-					print(f'UNHANDLED attrib_mod_auth VALUE: {mods}')
-					pprint.pprint(a)
-					continue
-		
-			subevent_id = event_id + f'-{seq_no}'
-			subevent = model.Production(ident=subevent_id, label=f'Production sub-event for {artist_label}')
-			subevent.carried_out_by = person
-			if uncertain_attribution:
-				assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'Possibly attributed to {artist_label}')
-				event.attributed_by = assignment
-				assignment.assigned_property = 'part'
-				assignment.assigned = subevent
-			else:
-				event.part = subevent
-		data['_artists'] = [a for a in artists if not is_or_anon(a)]
-		return data
-
-#mark - Physical Catalogs
-
-@use('non_auctions')
-def add_auction_catalog(data, non_auctions):
-	'''Add modeling for auction catalogs as linguistic objects'''
-	cno = data['catalog_number']
-
-	non_auction_flag = data.get('non_auction_flag')
-	if non_auction_flag:
-		non_auctions[cno] = non_auction_flag
-	else:
-		key = f'CATALOG-{cno}'
-		cdata = {'uid': key, 'uri': pir_uri('CATALOG', cno)}
-		catalog = vocab.AuctionCatalogText(ident=cdata['uri'])
-		catalog._label = f'Sale Catalog {cno}'
-
-		data['_catalog'] = add_crom_data(data=cdata, what=catalog)
-		yield data
-
-def add_physical_catalog_objects(data):
-	'''Add modeling for physical copies of an auction catalog'''
-	catalog = get_crom_object(data['_catalog'])
-	cno = data['catalog_number']
-	owner = data['owner_code']
-	copy = data['copy_number']
-	uri = pir_uri('CATALOG', cno, owner, copy)
-	data['uri'] = uri
-	labels = [f'Sale Catalog {cno}', f'owned by “{owner}”']
-	if copy:
-		labels.append(f'copy {copy}')
-	catalogObject = vocab.AuctionCatalog(ident=uri, label=', '.join(labels))
-	info = data.get('annotation_info')
-	if info:
-		catalogObject.referred_to_by = vocab.Note(ident='', content=info)
-	catalogObject.carries = catalog
-
-	add_crom_data(data=data, what=catalogObject)
-	return data
-
-@use('location_codes')
-@use('unique_catalogs')
-def add_physical_catalog_owners(data, location_codes, unique_catalogs):
-	'''Add information about the ownership of a physical copy of an auction catalog'''
-	# Add the URI of this physical catalog to `unique_catalogs`. This data will be used
-	# later to figure out which catalogs can be uniquely identified by a catalog number
-	# and owner code (e.g. for owners who do not have multiple copies of a catalog).
-	cno = data['catalog_number']
-	owner_code = data['owner_code']
-	owner_name = None
-	with suppress(KeyError):
-		owner_name = location_codes[owner_code]
-		owner_uri = pir_uri('ORGANIZATION', 'LOCATION-CODE', owner_code)
-		data['_owner'] = {
-			'label': owner_name,
-			'uri': owner_uri,
-			'identifiers': [
-				model.Name(ident='', content=owner_name),
-				model.Identifier(ident='', content=str(owner_code))
-			],
-		}
-		owner = model.Group(ident=owner_uri)
-		add_crom_data(data['_owner'], owner)
-		if not owner_code:
-			warnings.warn(f'Setting empty identifier on {owner.id}')
-		add_crom_data(data=data['_owner'], what=owner)
-		catalog = get_crom_object(data)
-		catalog.current_owner = owner
-
-	uri = pir_uri('CATALOG', cno, owner_code, None)
-	if uri not in unique_catalogs:
-		unique_catalogs[uri] = set()
-	unique_catalogs[uri].add(uri)
-	return data
-
-#mark - Physical Catalogs - Informational Catalogs
-
-class PopulateAuctionCatalog(Configurable):
-	'''Add modeling data for an auction catalog'''
-	static_instances = Option(default="static_instances")
-
-	def lugt_number_id(self, content):
-		lugt_number = str(content)
-		lugt_id = vocab.LocalNumber(ident='', label=f'Lugt Number: {lugt_number}', content=lugt_number)
-		assignment = model.AttributeAssignment(ident='')
-		assignment.carried_out_by = self.static_instances.get_instance('Person', 'lugt')
-		lugt_id.assigned_by = assignment
-		return lugt_id
-
-	def gri_number_id(self, content):
-		catalog_id = vocab.LocalNumber(ident='', content=content)
-		assignment = model.AttributeAssignment(ident='')
-		assignment.carried_out_by = self.static_instances.get_instance('Group', 'gri')
-		catalog_id.assigned_by = assignment
-		return catalog_id
-
-	def __call__(self, data):
-		d = {k: v for k, v in data.items()}
-		parent = data['parent_data']
-		cno = str(parent['catalog_number'])
-		sno = parent['star_record_no']
-		catalog = get_crom_object(d)
-		for lugt_no in parent.get('lugt', {}).values():
-			if not lugt_no:
-				warnings.warn(f'Setting empty identifier on {catalog.id}')
-			catalog.identified_by = self.lugt_number_id(lugt_no)
-
-		if not cno:
-			warnings.warn(f'Setting empty identifier on {catalog.id}')
-		catalog.identified_by = self.gri_number_id(cno)
-	
-		if not sno:
-			warnings.warn(f'Setting empty identifier on {catalog.id}')
-		catalog.identified_by = vocab.SystemNumber(ident='', content=sno)
-		notes = data.get('notes')
-		if notes:
-			note = vocab.Note(ident='', content=parent['notes'])
-			catalog.referred_to_by = note
-		return d
 
 #mark - Provenance Pipeline class
 
@@ -1585,9 +364,9 @@ class ProvenancePipeline(PipelineBase):
 	def add_physical_catalogs_chain(self, graph, records, serialize=True):
 		'''Add modeling of physical copies of auction catalogs.'''
 		catalogs = graph.add_chain(
-			add_auction_catalog,
-			add_physical_catalog_objects,
-			add_physical_catalog_owners,
+			pipeline.projects.provenance.catalogs.add_auction_catalog,
+			pipeline.projects.provenance.catalogs.add_physical_catalog_objects,
+			pipeline.projects.provenance.catalogs.add_physical_catalog_owners,
 			_input=records.output
 		)
 		if serialize:
@@ -1599,7 +378,7 @@ class ProvenancePipeline(PipelineBase):
 		'''Add modeling of auction catalogs as linguistic objects.'''
 		los = graph.add_chain(
 			ExtractKeyedValue(key='_catalog'),
-			PopulateAuctionCatalog(static_instances=self.static_instances),
+			pipeline.projects.provenance.catalogs.PopulateAuctionCatalog(static_instances=self.static_instances),
 			_input=events.output
 		)
 		if serialize:
@@ -1609,7 +388,6 @@ class ProvenancePipeline(PipelineBase):
 
 	def add_auction_events_chain(self, graph, records, serialize=True):
 		'''Add modeling of auction events.'''
-		helper = ProvenanceUtilityHelper()
 		auction_events = graph.add_chain(
 			GroupRepeatingKeys(
 				drop_empty=True,
@@ -1645,10 +423,10 @@ class ProvenancePipeline(PipelineBase):
 							'specific_loc')},
 				}
 			),
-			add_auction_catalog,
-			AddAuctionEvent(helper=self.helper),
-			AddAuctionHouses(helper=self.helper),
-			PopulateAuctionEvent(),
+			pipeline.projects.provenance.catalogs.add_auction_catalog,
+			pipeline.projects.provenance.events.AddAuctionEvent(helper=self.helper),
+			pipeline.projects.provenance.events.AddAuctionHouses(helper=self.helper),
+			pipeline.projects.provenance.events.PopulateAuctionEvent(helper=self.helper),
 			_input=records.output
 		)
 		if serialize:
@@ -1692,7 +470,7 @@ class ProvenancePipeline(PipelineBase):
 	def add_acquisitions_chain(self, graph, sales, serialize=True):
 		'''Add modeling of the acquisitions and bidding on lots being auctioned.'''
 		bid_acqs = graph.add_chain(
-			AddAcquisitionOrBidding(helper=self.helper),
+			pipeline.projects.provenance.lots.AddAcquisitionOrBidding(helper=self.helper),
 			_input=sales.output
 		)
 		orgs = graph.add_chain(
@@ -1900,7 +678,7 @@ class ProvenancePipeline(PipelineBase):
 						'ask_price_curr',
 						'ask_price_so')},
 			}),
-			AddAuctionOfLot(helper=self.helper),
+			pipeline.projects.provenance.lots.AddAuctionOfLot(helper=self.helper),
 			_input=records.output
 		)
 		if serialize:
@@ -1919,10 +697,10 @@ class ProvenancePipeline(PipelineBase):
 		'''Add modeling of the objects described by sales records.'''
 		objects = graph.add_chain(
 			ExtractKeyedValue(key='_object'),
-			add_object_type,
-			PopulateObject(helper=self.helper),
+			pipeline.projects.provenance.objects.add_object_type,
+			pipeline.projects.provenance.objects.PopulateObject(helper=self.helper),
 			pipeline.linkedart.MakeLinkedArtHumanMadeObject(),
-			AddArtists(),
+			pipeline.projects.provenance.objects.AddArtists(helper=self.helper),
 			_input=sales.output
 		)
 
@@ -2160,7 +938,7 @@ class ProvenancePipeline(PipelineBase):
 				dot.edge(i, j, f'{steps} steps')
 
 		self.persist_prev_post_sales_data(post_sale_rewrite_map)
-		
+
 		dot_filename = os.path.join(settings.pipeline_tmp_path, 'sales.dot')
 		dot.save(filename=dot_filename)
 		self.persist_sales_tree(g)
@@ -2194,12 +972,14 @@ class ProvenanceFilePipeline(ProvenancePipeline):
 		self.writers += nodes
 		return nodes
 
-	def persist_sales_tree(self, g):
+	@staticmethod
+	def persist_sales_tree(g):
 		sales_tree_filename = os.path.join(settings.pipeline_tmp_path, 'sales-tree.data')
 		with open(sales_tree_filename, 'w') as f:
 			g.dump(f)
 
-	def load_sales_tree(self):
+	@staticmethod
+	def load_sales_tree():
 		sales_tree_filename = os.path.join(settings.pipeline_tmp_path, 'sales-tree.data')
 		if os.path.exists(sales_tree_filename):
 			with open(sales_tree_filename) as f:
@@ -2208,7 +988,8 @@ class ProvenanceFilePipeline(ProvenancePipeline):
 			g = SalesTree()
 		return g
 
-	def load_prev_post_sales_data(self):
+	@staticmethod
+	def load_prev_post_sales_data():
 		rewrite_map_filename = os.path.join(settings.pipeline_tmp_path, 'post_sale_rewrite_map.json')
 		post_sale_rewrite_map = {}
 		if os.path.exists(rewrite_map_filename):
@@ -2217,7 +998,8 @@ class ProvenanceFilePipeline(ProvenancePipeline):
 					post_sale_rewrite_map = json.load(f)
 		return post_sale_rewrite_map
 
-	def persist_prev_post_sales_data(self, post_sale_rewrite_map):
+	@staticmethod
+	def persist_prev_post_sales_data(post_sale_rewrite_map):
 		rewrite_map_filename = os.path.join(settings.pipeline_tmp_path, 'post_sale_rewrite_map.json')
 		with open(rewrite_map_filename, 'w') as f:
 			json.dump(post_sale_rewrite_map, f)

--- a/pipeline/projects/provenance/catalogs.py
+++ b/pipeline/projects/provenance/catalogs.py
@@ -1,0 +1,129 @@
+import warnings
+import pprint
+from contextlib import suppress
+
+from bonobo.config import Option, Configurable, use
+
+from cromulent import model, vocab
+
+from pipeline.projects.provenance.util import pir_uri
+from pipeline.linkedart import add_crom_data, get_crom_object
+
+#mark - Physical Catalogs
+
+@use('non_auctions')
+def add_auction_catalog(data, non_auctions):
+	'''Add modeling for auction catalogs as linguistic objects'''
+	cno = data['catalog_number']
+
+	non_auction_flag = data.get('non_auction_flag')
+	if non_auction_flag:
+		non_auctions[cno] = non_auction_flag
+	else:
+		key = f'CATALOG-{cno}'
+		cdata = {'uid': key, 'uri': pir_uri('CATALOG', cno)}
+		catalog = vocab.AuctionCatalogText(ident=cdata['uri'])
+		catalog._label = f'Sale Catalog {cno}'
+
+		data['_catalog'] = add_crom_data(data=cdata, what=catalog)
+		yield data
+
+def add_physical_catalog_objects(data):
+	'''Add modeling for physical copies of an auction catalog'''
+	catalog = get_crom_object(data['_catalog'])
+	cno = data['catalog_number']
+	owner = data['owner_code']
+	copy = data['copy_number']
+	uri = pir_uri('CATALOG', cno, owner, copy)
+	data['uri'] = uri
+	labels = [f'Sale Catalog {cno}', f'owned by “{owner}”']
+	if copy:
+		labels.append(f'copy {copy}')
+	catalogObject = vocab.AuctionCatalog(ident=uri, label=', '.join(labels))
+	info = data.get('annotation_info')
+	if info:
+		catalogObject.referred_to_by = vocab.Note(ident='', content=info)
+	catalogObject.carries = catalog
+
+	add_crom_data(data=data, what=catalogObject)
+	return data
+
+@use('location_codes')
+@use('unique_catalogs')
+def add_physical_catalog_owners(data, location_codes, unique_catalogs):
+	'''Add information about the ownership of a physical copy of an auction catalog'''
+	# Add the URI of this physical catalog to `unique_catalogs`. This data will be used
+	# later to figure out which catalogs can be uniquely identified by a catalog number
+	# and owner code (e.g. for owners who do not have multiple copies of a catalog).
+	cno = data['catalog_number']
+	owner_code = data['owner_code']
+	owner_name = None
+	with suppress(KeyError):
+		owner_name = location_codes[owner_code]
+		owner_uri = pir_uri('ORGANIZATION', 'LOCATION-CODE', owner_code)
+		data['_owner'] = {
+			'label': owner_name,
+			'uri': owner_uri,
+			'identifiers': [
+				model.Name(ident='', content=owner_name),
+				model.Identifier(ident='', content=str(owner_code))
+			],
+		}
+		owner = model.Group(ident=owner_uri)
+		add_crom_data(data['_owner'], owner)
+		if not owner_code:
+			warnings.warn(f'Setting empty identifier on {owner.id}')
+		add_crom_data(data=data['_owner'], what=owner)
+		catalog = get_crom_object(data)
+		catalog.current_owner = owner
+
+	uri = pir_uri('CATALOG', cno, owner_code, None)
+	if uri not in unique_catalogs:
+		unique_catalogs[uri] = set()
+	unique_catalogs[uri].add(uri)
+	return data
+
+#mark - Physical Catalogs - Informational Catalogs
+
+class PopulateAuctionCatalog(Configurable):
+	'''Add modeling data for an auction catalog'''
+	static_instances = Option(default="static_instances")
+
+	def lugt_number_id(self, content):
+		lugt_number = str(content)
+		lugt_id = vocab.LocalNumber(ident='', label=f'Lugt Number: {lugt_number}', content=lugt_number)
+		assignment = model.AttributeAssignment(ident='')
+		assignment.carried_out_by = self.static_instances.get_instance('Person', 'lugt')
+		lugt_id.assigned_by = assignment
+		return lugt_id
+
+	def gri_number_id(self, content):
+		catalog_id = vocab.LocalNumber(ident='', content=content)
+		assignment = model.AttributeAssignment(ident='')
+		assignment.carried_out_by = self.static_instances.get_instance('Group', 'gri')
+		catalog_id.assigned_by = assignment
+		return catalog_id
+
+	def __call__(self, data):
+		d = {k: v for k, v in data.items()}
+		parent = data['parent_data']
+		cno = str(parent['catalog_number'])
+		sno = parent['star_record_no']
+		catalog = get_crom_object(d)
+		for lugt_no in parent.get('lugt', {}).values():
+			if not lugt_no:
+				warnings.warn(f'Setting empty identifier on {catalog.id}')
+			catalog.identified_by = self.lugt_number_id(lugt_no)
+
+		if not cno:
+			warnings.warn(f'Setting empty identifier on {catalog.id}')
+		catalog.identified_by = self.gri_number_id(cno)
+
+		if not sno:
+			warnings.warn(f'Setting empty identifier on {catalog.id}')
+		catalog.identified_by = vocab.SystemNumber(ident='', content=sno)
+		notes = data.get('notes')
+		if notes:
+			note = vocab.Note(ident='', content=parent['notes'])
+			catalog.referred_to_by = note
+		return d

--- a/pipeline/projects/provenance/events.py
+++ b/pipeline/projects/provenance/events.py
@@ -1,0 +1,171 @@
+import warnings
+import pprint
+from contextlib import suppress
+
+from bonobo.config import Option, Service, Configurable
+
+from cromulent import model, vocab
+
+import pipeline.execution
+from pipeline.projects.provenance.util import pir_uri
+from pipeline.util import implode_date, timespan_from_outer_bounds
+from pipeline.util.cleaners import parse_location
+import pipeline.linkedart
+from pipeline.linkedart import add_crom_data, get_crom_object
+
+#mark - Auction Events
+
+class AddAuctionEvent(Configurable):
+	helper = Option(required=True)
+
+	def __call__(self, data:dict):
+		'''Add modeling for an auction event based on properties of the supplied `data` dict.'''
+		cno = data['catalog_number']
+		auction, uid, uri = self.helper.auction_event_for_catalog_number(cno)
+		data['uid'] = uid
+		data['uri'] = uri
+		add_crom_data(data=data, what=auction)
+		catalog = get_crom_object(data['_catalog'])
+
+		record_uri = pir_uri('AUCTION-EVENT', 'CATALOGNUMBER', cno, 'RECORD')
+		label = f'Record of auction event from catalog {cno}'
+		record = model.LinguisticObject(ident=record_uri, label=label) # TODO: needs classification
+		record_data	= {'uri': record_uri}
+		record_data['identifiers'] = [model.Name(ident='', content=label)]
+		record.part_of = catalog
+
+		data['_record'] = add_crom_data(data=record_data, what=record)
+		return data
+
+class PopulateAuctionEvent(Configurable):
+	helper = Option(required=True)
+	auction_locations = Service('auction_locations')
+
+	def auction_event_location(self, data:dict):
+		'''
+		Based on location data in the supplied `data` dict, construct a data structure
+		representing a hierarchy of places (e.g. location->city->country), and return it.
+
+		This structure will be suitable for passing to `pipeline.linkedart.make_la_place`
+		to construct a Place model object.
+		'''
+		specific_name = data.get('specific_loc')
+		city_name = data.get('city_of_sale')
+		country_name = data.get('country_auth')
+
+		parts = [v for v in (specific_name, city_name, country_name) if v is not None]
+		loc = parse_location(*parts, uri_base=self.helper.uid_tag_prefix, types=('Place', 'City', 'Country'))
+		return loc
+
+	def __call__(self, data:dict, auction_locations):
+		'''Add modeling data for an auction event'''
+		cno = data['catalog_number']
+		auction = get_crom_object(data)
+		catalog = data['_catalog']['_LOD_OBJECT']
+
+		location_data = data['location']
+		current = self.auction_event_location(location_data)
+
+		# make_la_place is called here instead of as a separate graph node because the Place object
+		# gets stored in the `auction_locations` object to be used in the second graph component
+		# which uses the data to associate the place with auction lots.
+		base_uri = pir_uri('AUCTION-EVENT', 'CATALOGNUMBER', cno, 'PLACE')
+		place_data = pipeline.linkedart.make_la_place(current, base_uri=base_uri)
+		place = get_crom_object(place_data)
+		if place:
+			data['_locations'] = [place_data]
+			auction.took_place_at = place
+			auction_locations[cno] = place
+
+		begin = implode_date(data, 'sale_begin_', clamp='begin')
+		end = implode_date(data, 'sale_end_', clamp='eoe')
+		ts = timespan_from_outer_bounds(
+			begin=begin,
+			end=end,
+			inclusive=True
+		)
+		if begin and end:
+			ts.identified_by = model.Name(ident='', content=f'{begin} to {end}')
+		elif begin:
+			ts.identified_by = model.Name(ident='', content=f'{begin} onwards')
+		elif end:
+			ts.identified_by = model.Name(ident='', content=f'up to {end}')
+
+		for p in data.get('portal', []):
+			url = p['portal_url']
+			if url.startswith('http'):
+				auction.referred_to_by = vocab.WebPage(ident=url)
+			else:
+				warnings.warn(f'*** Portal URL value does not appear to be a valid URL: {url}')
+
+		if ts:
+			auction.timespan = ts
+
+		auction.referred_to_by = catalog
+		return data
+
+class AddAuctionHouses(Configurable):
+	helper = Option(required=True)
+	auction_houses = Service('auction_houses')
+
+	def add_auction_house_data(self, a, event_record):
+		'''Add modeling data for an auction house organization.'''
+		catalog = a.get('_catalog')
+
+		ulan = None
+		with suppress(ValueError, TypeError):
+			ulan = int(a.get('auc_house_ulan'))
+		auth_name = a.get('auc_house_auth')
+		a['identifiers'] = []
+		if ulan:
+			key = f'AUCTION-HOUSE-ULAN-{ulan}'
+			a['uid'] = key
+			a['uri'] = pir_uri('AUCTION-HOUSE', 'ULAN', ulan)
+			a['ulan'] = ulan
+			house = vocab.AuctionHouseOrg(ident=a['uri'])
+		elif auth_name and auth_name not in self.helper.ignore_house_authnames:
+			a['uri'] = pir_uri('AUCTION-HOUSE', 'AUTHNAME', auth_name)
+			pname = vocab.PrimaryName(ident='', content=auth_name)
+			pname.referred_to_by = event_record
+			a['identifiers'].append(pname)
+			house = vocab.AuctionHouseOrg(ident=a['uri'])
+		else:
+			# not enough information to identify this house uniquely, so use the source location in the input file
+			a['uri'] = pir_uri('AUCTION-HOUSE', 'CAT_NO', 'CATALOG-NUMBER', a['catalog_number'])
+			house = vocab.AuctionHouseOrg(ident=a['uri'])
+
+		name = a.get('auc_house_name') or a.get('name')
+		if name:
+			n = model.Name(ident='', content=name)
+			n.referred_to_by = event_record
+			a['identifiers'].append(n)
+			a['label'] = name
+		else:
+			a['label'] = '(Anonymous)'
+
+		add_crom_data(data=a, what=house)
+		return a
+
+	def __call__(self, data:dict, auction_houses):
+		'''
+		Add modeling data for the auction house organization(s) associated with an auction
+		event.
+		'''
+		auction = get_crom_object(data)
+		event_record = get_crom_object(data['_record'])
+		catalog = data['_catalog']['_LOD_OBJECT']
+		d = data.copy()
+		houses = data.get('auction_house', [])
+		cno = data['catalog_number']
+
+		house_objects = []
+		event_record = get_crom_object(data['_record'])
+		for h in houses:
+			h['_catalog'] = catalog
+			self.add_auction_house_data(self.helper.copy_source_information(h, data), event_record)
+			house = get_crom_object(h)
+			auction.carried_out_by = house
+			if auction_houses:
+				house_objects.append(house)
+		auction_houses[cno] = house_objects
+		return d

--- a/pipeline/projects/provenance/lots.py
+++ b/pipeline/projects/provenance/lots.py
@@ -1,0 +1,494 @@
+import warnings
+import pprint
+from contextlib import suppress
+
+from bonobo.config import Option, Service, Configurable
+
+from cromulent import model, vocab
+
+import pipeline.execution
+from pipeline.projects.provenance.util import object_key
+from pipeline.util import \
+		implode_date, \
+		timespan_from_outer_bounds, \
+		timespan_before, \
+		timespan_after
+from pipeline.util.cleaners import parse_location_name
+import pipeline.linkedart
+from pipeline.linkedart import add_crom_data, get_crom_object
+
+#mark - Auction of Lot
+
+class AddAuctionOfLot(Configurable):
+	'''Add modeling data for the auction of a lot of objects.'''
+
+	helper = Option(required=True)
+	problematic_records = Service('problematic_records')
+	auction_locations = Service('auction_locations')
+	auction_houses = Service('auction_houses')
+	non_auctions = Service('non_auctions')
+	def __init__(self, *args, **kwargs):
+		self.lot_cache = {}
+		super().__init__(*args, **kwargs)
+
+	@staticmethod
+	def set_lot_auction_houses(lot, cno, auction_houses):
+		'''Associate the auction house with the auction lot.'''
+		houses = auction_houses.get(cno)
+		if houses:
+			for house in houses:
+				lot.carried_out_by = house
+
+	@staticmethod
+	def set_lot_location(lot, cno, auction_locations):
+		'''Associate the location with the auction lot.'''
+		place = auction_locations.get(cno)
+		if place:
+			lot.took_place_at = place
+
+	@staticmethod
+	def set_lot_date(lot, auction_data):
+		'''Associate a timespan with the auction lot.'''
+		date = implode_date(auction_data, 'lot_sale_')
+# 		dates = date_parse(date, delim='-')
+# 		if dates:
+		if date:
+			begin = implode_date(auction_data, 'lot_sale_', clamp='begin')
+			end = implode_date(auction_data, 'lot_sale_', clamp='eoe')
+			bounds = [begin, end]
+		else:
+			bounds = []
+		if bounds:
+			ts = timespan_from_outer_bounds(*bounds)
+			ts.identified_by = model.Name(ident='', content=date)
+			lot.timespan = ts
+
+	def set_lot_notes(self, lot, auction_data):
+		'''Associate notes with the auction lot.'''
+		cno, lno, _ = object_key(auction_data)
+		auction, _, _ = self.helper.auction_event_for_catalog_number(cno)
+		notes = auction_data.get('lot_notes')
+		if notes:
+			note_id = lot.id + '-LotNotes'
+			lot.referred_to_by = vocab.Note(ident=note_id, content=notes)
+		if not lno:
+			warnings.warn(f'Setting empty identifier on {lot.id}')
+		lno = str(lno)
+		lot.identified_by = vocab.LotNumber(ident='', content=lno)
+		lot.part_of = auction
+
+	def set_lot_objects(self, lot, cno, lno, data):
+		'''Associate the set of objects with the auction lot.'''
+		coll = vocab.AuctionLotSet(ident=f'{data["uri"]}-Set')
+		shared_lot_number = self.helper.shared_lot_number_from_lno(lno)
+		coll._label = f'Auction Lot {cno} {shared_lot_number}'
+		est_price = data.get('estimated_price')
+		if est_price:
+			coll.dimension = get_crom_object(est_price)
+		start_price = data.get('start_price')
+		if start_price:
+			coll.dimension = get_crom_object(start_price)
+
+		lot.used_specific_object = coll
+		data['_lot_object_set'] = add_crom_data(data={}, what=coll)
+
+	def __call__(self, data, non_auctions, auction_houses, auction_locations, problematic_records):
+		'''Add modeling data for the auction of a lot of objects.'''
+		ask_price = data.get('ask_price', {}).get('ask_price')
+		if ask_price:
+			# if there is an asking price/currency, it's a direct sale, not an auction;
+			# filter these out from subsequent modeling of auction lots.
+			return
+
+		self.helper.copy_source_information(data['_object'], data)
+
+		auction_data = data['auction_of_lot']
+		try:
+			lot_object_key = object_key(auction_data)
+		except Exception as e:
+			warnings.warn(f'Failed to compute lot object key from data {auction_data} ({e})')
+			pprint.pprint({k: v for k, v in data.items() if v != ''})
+			raise
+		cno, lno, date = lot_object_key
+		if cno in non_auctions:
+			# the records in this sales catalog do not represent auction sales, so should
+			# be skipped.
+			return
+
+		shared_lot_number = self.helper.shared_lot_number_from_lno(lno)
+		uid, uri = self.helper.shared_lot_number_ids(cno, lno, date)
+		data['uid'] = uid
+		data['uri'] = uri
+
+		lot = vocab.Auction(ident=data['uri'])
+		lot_id = f'{cno} {shared_lot_number} ({date})'
+		lot_object_id = f'{cno} {lno} ({date})'
+		lot_label = f'Auction of Lot {lot_id}'
+		lot._label = lot_label
+		data['lot_id'] = lot_id
+		data['lot_object_id'] = lot_object_id
+
+		for problem_key, problem in problematic_records.get('lots', []):
+			# TODO: this is inefficient, but will probably be OK so long as the number
+			#       of problematic records is small. We do it this way because we can't
+			#       represent a tuple directly as a JSON dict key, and we don't want to
+			#       have to do post-processing on the services JSON files after loading.
+			if tuple(problem_key) == lot_object_key:
+				note = model.LinguisticObject(ident='', content=problem)
+				note.classified_as = vocab.instances["brief text"]
+				note.classified_as = model.Type(
+					ident=self.helper.problematic_record_uri,
+					label='Problematic Record'
+				)
+				lot.referred_to_by = note
+
+		self.set_lot_auction_houses(lot, cno, auction_houses)
+		self.set_lot_location(lot, cno, auction_locations)
+		self.set_lot_date(lot, auction_data)
+		self.set_lot_notes(lot, auction_data)
+		self.set_lot_objects(lot, cno, lno, data)
+
+		tx_uri = self.helper.transaction_uri_for_lot(auction_data, data.get('price', []))
+		lots = self.helper.lots_in_transaction(auction_data, data.get('price', []))
+		multi = self.helper.transaction_contains_multiple_lots(auction_data, data.get('price', []))
+		tx = vocab.Procurement(ident=tx_uri)
+		tx._label = f'Procurement of Lot {cno} {lots} ({date})'
+		lot.caused = tx
+		tx_data = {'uri': tx_uri}
+
+		if multi:
+			tx_data['multi_lot_tx'] = lots
+		with suppress(AttributeError):
+			tx_data['_date'] = lot.timespan
+		data['_procurement_data'] = add_crom_data(data=tx_data, what=tx)
+
+		add_crom_data(data=data, what=lot)
+		yield data
+
+class AddAcquisitionOrBidding(Configurable):
+	helper = Option(required=True)
+	buy_sell_modifiers = Service('buy_sell_modifiers')
+	make_la_person = Service('make_la_person')
+
+	@staticmethod
+	def related_procurement(current_tx, hmo, current_ts=None, buyer=None, seller=None, previous=False):
+		'''
+		Returns a new `vocab.Procurement` object (and related acquisition) that is temporally
+		related to the supplied procurement and associated data. The new procurement is for
+		the given object, and has the given buyer and seller (both optional).
+
+		If the `previous` flag is `True`, the new procurement is occurs before `current_tx`,
+		and if the timespan `current_ts` is given, has temporal data to that effect. If
+		`previous` is `False`, this relationship is reversed.
+		'''
+		tx = vocab.Procurement()
+		if current_tx:
+			if previous:
+				tx.ends_before_the_start_of = current_tx
+			else:
+				tx.starts_after_the_end_of = current_tx
+		modifier_label = 'Previous' if previous else 'Subsequent'
+		try:
+			pacq = model.Acquisition(ident='', label=f'{modifier_label} Acquisition of: “{hmo._label}”')
+		except AttributeError:
+			pacq = model.Acquisition(ident='', label=f'{modifier_label} Acquisition')
+		pacq.transferred_title_of = hmo
+		if buyer:
+			pacq.transferred_title_to = buyer
+		if seller:
+			pacq.transferred_title_from = seller
+		tx.part = pacq
+		if current_ts:
+			if previous:
+				pacq.timespan = timespan_before(current_ts)
+			else:
+				pacq.timespan = timespan_after(current_ts)
+		return tx
+
+	def final_owner_procurement(self, final_owner, current_tx, hmo, current_ts):
+		tx = self.related_procurement(current_tx, hmo, current_ts, buyer=final_owner)
+		try:
+			object_label = hmo._label
+			tx._label = f'Procurement leading to the currently known location of “{object_label}”'
+		except AttributeError:
+			tx._label = f'Procurement leading to the currently known location of object'
+		return tx
+
+	def add_acquisition(self, data, buyers, sellers, buy_sell_modifiers, make_la_person=None):
+		'''Add modeling of an acquisition as a transfer of title from the seller to the buyer'''
+		sales_record = get_crom_object(data['_record'])
+		hmo = get_crom_object(data)
+		parent = data['parent_data']
+	# 	transaction = parent['transaction']
+		prices = parent['price']
+		auction_data = parent['auction_of_lot']
+		cno, lno, date = object_key(auction_data)
+		data['buyer'] = buyers
+		data['seller'] = sellers
+
+		acq_label = None
+		try:
+			object_label = f'“{hmo._label}”'
+			acq_label = f'Acquisition of {cno} {lno} ({date}): {object_label}'
+		except AttributeError:
+			object_label = '(object)'
+			acq_label = f'Acquisition of {cno} {lno} ({date})'
+		amnts = [get_crom_object(p) for p in prices]
+
+	# 	if not prices:
+	# 		print(f'*** No price data found for {transaction} transaction')
+
+		tx_data = parent['_procurement_data']
+		current_tx = get_crom_object(tx_data)
+		payment_id = current_tx.id + '-Payment'
+
+		acq_id = hmo.id + '-Acquisition'
+		acq = model.Acquisition(ident=acq_id, label=acq_label)
+		acq.transferred_title_of = hmo
+
+		multi = tx_data.get('multi_lot_tx')
+		paym_label = f'multiple lots {multi}' if multi else object_label
+		paym = model.Payment(ident=payment_id, label=f'Payment for {paym_label}')
+
+		THROUGH = set(buy_sell_modifiers['through'])
+		FOR = set(buy_sell_modifiers['for'])
+
+		for seller_data in sellers:
+			seller = get_crom_object(seller_data)
+			mod = seller_data.get('auth_mod_a', '')
+
+			if mod == 'or':
+				mod_non_auth = seller_data.get('auth_mod')
+				if mod_non_auth:
+					acq.referred_to_by = vocab.Note(ident='', label=f'Seller modifier', content=mod_non_auth)
+				warnings.warn('Handle OR buyer modifier') # TODO: some way to model this uncertainty?
+
+			if mod in THROUGH:
+				acq.carried_out_by = seller
+				paym.carried_out_by = seller
+			elif mod in FOR:
+				acq.transferred_title_from = seller
+				paym.paid_to = seller
+			else:
+				# covers non-modified
+				acq.carried_out_by = seller
+				acq.transferred_title_from = seller
+				paym.carried_out_by = seller
+				paym.paid_to = seller
+
+		for buyer_data in buyers:
+			buyer = get_crom_object(buyer_data)
+			mod = buyer_data.get('auth_mod_a', '')
+
+			if mod == 'or':
+				# or/or others/or another
+				mod_non_auth = buyer_data.get('auth_mod')
+				if mod_non_auth:
+					acq.referred_to_by = vocab.Note(ident='', label=f'Buyer modifier', content=mod_non_auth)
+				warnings.warn(f'Handle buyer modifier: {mod}') # TODO: some way to model this uncertainty?
+
+			if mod in THROUGH:
+				acq.carried_out_by = buyer
+				paym.carried_out_by = buyer
+			elif mod in FOR:
+				acq.transferred_title_to = buyer
+				paym.paid_from = buyer
+			else:
+				# covers non-modified
+				acq.carried_out_by = buyer
+				acq.transferred_title_to = buyer
+				paym.carried_out_by = buyer
+				paym.paid_from = buyer
+
+		if len(amnts) > 1:
+			warnings.warn(f'Multiple Payment.paid_amount values for object {hmo.id} ({payment_id})')
+		for amnt in amnts:
+			paym.paid_amount = amnt
+			break # TODO: sensibly handle multiplicity in paid amount data
+
+		ts = tx_data.get('_date')
+		if ts:
+			acq.timespan = ts
+		current_tx.part = paym
+		current_tx.part = acq
+		if '_procurements' not in data:
+			data['_procurements'] = []
+		data['_procurements'] += [add_crom_data(data={}, what=current_tx)]
+	# 	lot_uid, lot_uri = helper.shared_lot_number_ids(cno, lno)
+		# TODO: `annotation` here is from add_physical_catalog_objects
+	# 	paym.referred_to_by = annotation
+
+		data['_acquisition'] = add_crom_data(data={'uri': acq_id}, what=acq)
+
+		final_owner_data = data.get('_final_org', [])
+		if final_owner_data:
+			data['_organizations'].append(final_owner_data)
+			final_owner = get_crom_object(final_owner_data)
+			tx = self.final_owner_procurement(final_owner, current_tx, hmo, ts)
+			data['_procurements'].append(add_crom_data(data={}, what=tx))
+
+		post_own = data.get('post_owner', [])
+		prev_own = data.get('prev_owner', [])
+		prev_post_owner_records = [(post_own, False), (prev_own, True)]
+		for owner_data, rev in prev_post_owner_records:
+			if rev:
+				rev_name = 'prev-owner'
+				source_label = 'Source of information on history of the object prior to the current sale.'
+			else:
+				rev_name = 'post-owner'
+				source_label = 'Source of information on history of the object after the current sale.'
+			for seq_no, owner_record in enumerate(owner_data):
+				ignore_fields = ('own_so', 'own_auth_l', 'own_auth_d')
+				if not any([bool(owner_record.get(k)) for k in owner_record.keys() if k not in ignore_fields]):
+					# some records seem to have metadata (source information, location, or notes) but no other fields set
+					# these should not constitute actual records of a prev/post owner.
+					continue
+				owner_record.update({
+					'pi_record_no': data['pi_record_no'],
+					'ulan': owner_record['own_ulan'],
+					'auth_name': owner_record['own_auth'],
+					'name': owner_record['own']
+				})
+				pi = self.helper.person_identity
+				pi.add_uri(owner_record, record_id=f'{rev_name}-{seq_no+1}')
+				pi.add_names(owner_record, referrer=sales_record, role='artist')
+				make_la_person(owner_record)
+				owner = get_crom_object(owner_record)
+
+				# TODO: handle other fields of owner_record: own_auth_d, own_auth_q, own_ques, own_so
+
+				if owner_record.get('own_auth_l'):
+					loc = owner_record['own_auth_l']
+					current = parse_location_name(loc, uri_base=self.helper.uid_tag_prefix)
+					place_data = pipeline.linkedart.make_la_place(current)
+					place = get_crom_object(place_data)
+					owner.residence = place
+					data['_owner_locations'].append(place_data)
+
+				if '_other_owners' not in data:
+					data['_other_owners'] = []
+				data['_other_owners'].append(owner_record)
+
+				tx = self.related_procurement(current_tx, hmo, ts, buyer=owner, previous=rev)
+
+				own_info_source = owner_record.get('own_so')
+				if own_info_source:
+					note = vocab.SourceStatement(ident='', content=own_info_source, label=source_label)
+					tx.referred_to_by = note
+
+				ptx_data = tx_data.copy()
+				data['_procurements'].append(add_crom_data(data=ptx_data, what=tx))
+		yield data
+
+	def add_bidding(self, data:dict, buyers, buy_sell_modifiers):
+		'''Add modeling of bids that did not lead to an acquisition'''
+		parent = data['parent_data']
+		prices = parent['price']
+		amnts = [get_crom_object(p) for p in prices]
+
+		if amnts:
+			auction_data = parent['auction_of_lot']
+			cno, lno, date = object_key(auction_data)
+			lot = get_crom_object(parent)
+			hmo = get_crom_object(data)
+			bidding_id = hmo.id + '-Bidding'
+			all_bids = model.Activity(ident=bidding_id, label=f'Bidding on {cno} {lno} ({date})')
+
+			all_bids.part_of = lot
+
+			THROUGH = set(buy_sell_modifiers['through'])
+			FOR = set(buy_sell_modifiers['for'])
+
+			for seq_no, amnt in enumerate(amnts):
+				bid_id = hmo.id + f'-Bid-{seq_no}'
+				bid = vocab.Bidding(ident=bid_id)
+				prop_id = hmo.id + f'-Bid-{seq_no}-Promise'
+				try:
+					amnt_label = amnt._label
+					bid._label = f'Bid of {amnt_label} on {cno} {lno} ({date})'
+					prop = model.PropositionalObject(ident=prop_id, label=f'Promise to pay {amnt_label}')
+				except AttributeError:
+					bid._label = f'Bid on {cno} {lno} ({date})'
+					prop = model.PropositionalObject(ident=prop_id, label=f'Promise to pay')
+
+				prop.refers_to = amnt
+				bid.created = prop
+
+				# TODO: there are often no buyers listed for non-sold records.
+				#       should we construct an anonymous person to carry out the bid?
+				for buyer_data in buyers:
+					buyer = get_crom_object(buyer_data)
+					mod = buyer_data.get('auth_mod_a', '')
+					if mod in THROUGH:
+						bid.carried_out_by = buyer
+					elif mod in FOR:
+						warnings.warn(f'buyer modifier {mod} for non-sale bidding: {cno} {lno} {date}')
+					else:
+						bid.carried_out_by = buyer
+
+				all_bids.part = bid
+
+			final_owner_data = data.get('_final_org')
+			if final_owner_data:
+				data['_organizations'].append(final_owner_data)
+				final_owner = get_crom_object(final_owner_data)
+				ts = lot.timespan
+				hmo = get_crom_object(data)
+				tx = self.final_owner_procurement(final_owner, None, hmo, ts)
+				if '_procurements' not in data:
+					data['_procurements'] = []
+				data['_procurements'].append(add_crom_data(data={}, what=tx))
+
+			data['_bidding'] = {'uri': bidding_id}
+			add_crom_data(data=data['_bidding'], what=all_bids)
+			yield data
+		else:
+			warnings.warn(f'*** No price data found for {parent["transaction"]!r} transaction')
+			yield data
+
+	def add_person(self, data:dict, sales_record, rec_id, *, make_la_person):
+		'''
+		Add modeling data for people, based on properties of the supplied `data` dict.
+
+		This function adds properties to `data` before calling
+		`pipeline.linkedart.MakeLinkedArtPerson` to construct the model objects.
+		'''
+		pi = self.helper.person_identity
+		pi.add_uri(data, record_id=rec_id)
+		pi.add_names(data, referrer=sales_record)
+
+		make_la_person(data)
+		return data
+
+	def __call__(self, data:dict, buy_sell_modifiers, make_la_person):
+		'''Determine if this record has an acquisition or bidding, and add appropriate modeling'''
+		parent = data['parent_data']
+		sales_record = get_crom_object(data['_record'])
+		transaction = parent['transaction']
+		transaction = transaction.replace('[?]', '').rstrip()
+
+		buyers = [
+			self.add_person(
+				self.helper.copy_source_information(p, parent),
+				sales_record,
+				f'buyer_{i+1}',
+				make_la_person=make_la_person
+			) for i, p in enumerate(parent['buyer'])
+		]
+
+		# TODO: is this the right set of transaction types to represent acquisition?
+		if transaction in ('Sold', 'Vendu', 'Verkauft', 'Bought In'):
+			sellers = [
+				self.add_person(
+					self.helper.copy_source_information(p, parent),
+					sales_record,
+					f'seller_{i+1}',
+					make_la_person=make_la_person
+				) for i, p in enumerate(parent['seller'])
+			]
+			data['_owner_locations'] = []
+			yield from self.add_acquisition(data, buyers, sellers, buy_sell_modifiers, make_la_person)
+		elif transaction in ('Unknown', 'Unbekannt', 'Inconnue', 'Withdrawn', 'Non Vendu', ''):
+			yield from self.add_bidding(data, buyers, buy_sell_modifiers)
+		else:
+			warnings.warn(f'Cannot create acquisition data for unknown transaction type: {transaction!r}')

--- a/pipeline/projects/provenance/objects.py
+++ b/pipeline/projects/provenance/objects.py
@@ -1,0 +1,489 @@
+import re
+import warnings
+import pprint
+from contextlib import suppress
+
+from bonobo.config import Option, Service, Configurable, use
+
+from cromulent import model, vocab
+from cromulent.extract import extract_physical_dimensions
+
+import pipeline.execution
+from pipeline.projects.provenance.util import pir_uri
+from pipeline.util import implode_date, timespan_from_outer_bounds
+from pipeline.util.cleaners import \
+			parse_location_name, \
+			date_cleaner
+import pipeline.linkedart
+from pipeline.linkedart import add_crom_data, get_crom_object
+from pipeline.util import truncate_with_ellipsis
+
+#mark - Auction of Lot - Physical Object
+
+class PopulateObject(Configurable):
+	helper = Option(required=True)
+	post_sale_map = Service('post_sale_map')
+	unique_catalogs = Service('unique_catalogs')
+	vocab_instance_map = Service('vocab_instance_map')
+	destruction_types_map = Service('destruction_types_map')
+
+	def genre_instance(self, value, vocab_instance_map):
+		'''Return the appropriate type instance for the supplied genre name'''
+		if value is None:
+			return None
+		value = value.lower()
+
+		instance_name = vocab_instance_map.get(value)
+		if instance_name:
+			instance = vocab.instances.get(instance_name)
+			if not instance:
+				warnings.warn(f'*** No genre instance available for {instance_name!r} in vocab_instance_map')
+			return instance
+		return None
+
+	def populate_destruction_events(self, data:dict, note, *, type_map, location=None):
+		destruction_types_map = type_map
+		hmo = get_crom_object(data)
+		title = data.get('title')
+		short_title = truncate_with_ellipsis(title, 100) or title
+
+		r = re.compile(r'[Dd]estroyed(?: (?:by|during) (\w+))?(?: in (\d{4})[.]?)?')
+		m = r.search(note)
+		if m:
+			method = m.group(1)
+			year = m.group(2)
+			dest_id = hmo.id + '-Destruction'
+			d = model.Destruction(ident=dest_id, label=f'Destruction of “{short_title}”')
+			d.referred_to_by = vocab.Note(ident='', content=note)
+			if year is not None:
+				begin, end = date_cleaner(year)
+				ts = timespan_from_outer_bounds(begin, end)
+				ts.identified_by = model.Name(ident='', content=year)
+				d.timespan = ts
+
+			if method:
+				with suppress(KeyError, AttributeError):
+					type_name = destruction_types_map[method.lower()]
+					otype = vocab.instances[type_name]
+					event = model.Event(label=f'{method.capitalize()} event causing the destruction of “{short_title}”')
+					event.classified_as = otype
+					d.caused_by = event
+					data['_events'].append(add_crom_data(data={}, what=event))
+
+			if location:
+				current = parse_location_name(location, uri_base=self.helper.uid_tag_prefix)
+				base_uri = hmo.id + '-Place,'
+				place_data = pipeline.linkedart.make_la_place(current, base_uri=base_uri)
+				place = get_crom_object(place_data)
+				if place:
+					data['_locations'].append(place_data)
+					d.took_place_at = place
+
+			hmo.destroyed_by = d
+
+	def _populate_object_visual_item(self, data:dict, vocab_instance_map):
+		hmo = get_crom_object(data)
+		title = data.get('title')
+		title = truncate_with_ellipsis(title, 100) or title
+
+		vi_id = hmo.id + '-VisualItem'
+		vi = model.VisualItem(ident=vi_id)
+		vidata = {'uri': vi_id}
+		if title:
+			vidata['label'] = f'Visual work of “{title}”'
+			sales_record = get_crom_object(data['_record'])
+			vidata['names'] = [(title,{'referred_to_by': [sales_record]})]
+
+		genre = self.genre_instance(data.get('genre'), vocab_instance_map)
+		if genre:
+			vi.classified_as = genre
+		data['_visual_item'] = add_crom_data(data=vidata, what=vi)
+		hmo.shows = vi
+
+	@staticmethod
+	def _populate_object_catalog_record(data:dict, parent, lot, cno, rec_num):
+		catalog_uri = pir_uri('CATALOG', cno)
+		catalog = vocab.AuctionCatalogText(ident=catalog_uri)
+
+		record_uri = pir_uri('CATALOG', cno, 'RECORD', rec_num)
+		lot_object_id = parent['lot_object_id']
+		record = model.LinguisticObject(ident=record_uri, label=f'Sale recorded in catalog: {lot_object_id} (record number {rec_num})') # TODO: needs classification
+		record_data	= {'uri': record_uri}
+		record_data['identifiers'] = [model.Name(ident='', content=f'Record of sale {lot_object_id}')]
+		record.part_of = catalog
+
+		data['_record'] = add_crom_data(data=record_data, what=record)
+		return record
+
+	def _populate_object_destruction(self, data:dict, parent, destruction_types_map):
+		notes = parent.get('auction_of_lot', {}).get('lot_notes')
+		if notes and notes.lower().startswith('destroyed'):
+			self.populate_destruction_events(data, notes, type_map=destruction_types_map)
+
+	@staticmethod
+	def _populate_object_statements(data:dict):
+		hmo = get_crom_object(data)
+		materials = data.get('materials')
+		if materials:
+			matstmt = vocab.MaterialStatement(ident='', content=materials)
+			sales_record = get_crom_object(data['_record'])
+			matstmt.referred_to_by = sales_record
+			hmo.referred_to_by = matstmt
+
+		dimstr = data.get('dimensions')
+		if dimstr:
+			dimstmt = vocab.DimensionStatement(ident='', content=dimstr)
+			sales_record = get_crom_object(data['_record'])
+			dimstmt.referred_to_by = sales_record
+			hmo.referred_to_by = dimstmt
+			for dim in extract_physical_dimensions(dimstr):
+				dim.referred_to_by = sales_record
+				hmo.dimension = dim
+		else:
+			pass
+	# 		print(f'No dimension data was parsed from the dimension statement: {dimstr}')
+
+	def _populate_object_present_location(self, data:dict, now_key, destruction_types_map):
+		hmo = get_crom_object(data)
+		location = data.get('present_location')
+		if location:
+			loc = location.get('geog')
+			note = location.get('note')
+			if loc:
+				if 'destroyed ' in loc.lower():
+					self.populate_destruction_events(data, loc, type_map=destruction_types_map)
+				elif isinstance(note, str) and 'destroyed ' in note.lower():
+					# the object was destroyed, so any "present location" data is actually
+					# an indication of the location of destruction.
+					self.populate_destruction_events(data, note, type_map=destruction_types_map, location=loc)
+				else:
+					# TODO: if `parse_location_name` fails, still preserve the location string somehow
+					current = parse_location_name(loc, uri_base=self.helper.uid_tag_prefix)
+					inst = location.get('inst')
+					if inst:
+						owner_data = {
+							'label': f'{inst} ({loc})',
+							'identifiers': [
+								model.Name(ident='', content=inst)
+							]
+						}
+						ulan = None
+						with suppress(ValueError, TypeError):
+							ulan = int(location.get('insi'))
+						if ulan:
+							owner_data['ulan'] = ulan
+							owner_data['uri'] = pir_uri('ORGANIZATION', 'ULAN', ulan)
+						else:
+							owner_data['uri'] = pir_uri('ORGANIZATION', 'NAME', inst, 'PLACE', loc)
+					else:
+						owner_data = {
+							'label': '(Anonymous organization)',
+							'uri': pir_uri('ORGANIZATION', 'PRESENT-OWNER', *now_key),
+						}
+
+					base_uri = hmo.id + '-Place,'
+					place_data = pipeline.linkedart.make_la_place(current, base_uri=base_uri)
+					place = get_crom_object(place_data)
+
+					make_la_org = pipeline.linkedart.MakeLinkedArtOrganization()
+					owner_data = make_la_org(owner_data)
+					owner = get_crom_object(owner_data)
+					owner.residence = place
+					data['_locations'].append(place_data)
+					data['_final_org'] = owner_data
+			else:
+				pass # there is no present location place string
+			if note:
+				pass
+				# TODO: the acquisition_note needs to be attached as a Note to the final post owner acquisition
+
+	def _populate_object_notes(self, data:dict, parent, unique_catalogs):
+		hmo = get_crom_object(data)
+		notes = data.get('hand_note', [])
+		for note in notes:
+			hand_note_content = note['hand_note']
+			owner = note.get('hand_note_so')
+			cno = parent['auction_of_lot']['catalog_number']
+			catalog_uri = pir_uri('CATALOG', cno, owner, None)
+			catalogs = unique_catalogs.get(catalog_uri)
+			note = vocab.Note(ident='', content=hand_note_content)
+			hmo.referred_to_by = note
+			if catalogs and len(catalogs) == 1:
+				note.carried_by = vocab.AuctionCatalog(ident=catalog_uri, label=f'Sale Catalog {cno}, owned by “{owner}”')
+
+		inscription = data.get('inscription')
+		if inscription:
+			hmo.referred_to_by = vocab.InscriptionStatement(ident='', content=inscription)
+
+	def _populate_object_prev_post_sales(self, data:dict, this_key, post_sale_map):
+		post_sales = data.get('post_sale', [])
+		prev_sales = data.get('prev_sale', [])
+		prev_post_sales_records = [(post_sales, False), (prev_sales, True)]
+		for sales_data, rev in prev_post_sales_records:
+			for sale_record in sales_data:
+				pcno = sale_record.get('cat')
+				plno = sale_record.get('lot')
+				plot = self.helper.shared_lot_number_from_lno(plno)
+				pdate = implode_date(sale_record, '')
+				if pcno and plot and pdate:
+					that_key = (pcno, plot, pdate)
+					if rev:
+						# `that_key` is for a previous sale for this object
+						post_sale_map[this_key] = that_key
+					else:
+						# `that_key` is for a later sale for this object
+						post_sale_map[that_key] = this_key
+
+	def __call__(self, data:dict, post_sale_map, unique_catalogs, vocab_instance_map, destruction_types_map):
+		'''Add modeling for an object described by a sales record'''
+		hmo = get_crom_object(data)
+		parent = data['parent_data']
+		auction_data = parent.get('auction_of_lot')
+		if auction_data:
+			lno = str(auction_data['lot_number'])
+			if 'identifiers' not in data:
+				data['identifiers'] = []
+			if not lno:
+				warnings.warn(f'Setting empty identifier on {hmo.id}')
+			data['identifiers'].append(vocab.LotNumber(ident='', content=lno))
+		else:
+			warnings.warn(f'***** NO AUCTION DATA FOUND IN populate_object')
+
+
+		cno = auction_data['catalog_number']
+		lno = auction_data['lot_number']
+		date = implode_date(auction_data, 'lot_sale_')
+		lot = self.helper.shared_lot_number_from_lno(lno)
+		now_key = (cno, lot, date) # the current key for this object; may be associated later with prev and post object keys
+
+		data['_locations'] = []
+		data['_events'] = []
+		record = self._populate_object_catalog_record(data, parent, lot, cno, parent['pi_record_no'])
+		self._populate_object_visual_item(data, vocab_instance_map)
+		self._populate_object_destruction(data, parent, destruction_types_map)
+		self._populate_object_statements(data)
+		self._populate_object_present_location(data, now_key, destruction_types_map)
+		self._populate_object_notes(data, parent, unique_catalogs)
+		self._populate_object_prev_post_sales(data, now_key, post_sale_map)
+		for p in data.get('portal', []):
+			url = p['portal_url']
+			hmo.referred_to_by = vocab.WebPage(ident=url)
+
+		if 'title' in data:
+			title = data['title']
+			if not hasattr(hmo, '_label'):
+				typestring = data.get('object_type', 'Object')
+				hmo._label = f'{typestring}: “{title}”'
+			del data['title']
+			shorter = truncate_with_ellipsis(title, 100)
+			if shorter:
+				description = vocab.Description(ident='', content=title)
+				description.referred_to_by = record
+				hmo.referred_to_by = description
+				title = shorter
+			t = vocab.PrimaryName(ident='', content=title)
+			t.classified_as = model.Type(ident='http://vocab.getty.edu/aat/300417193', label='Title')
+			t.referred_to_by = record
+			data['identifiers'].append(t)
+
+		return data
+
+@use('vocab_type_map')
+def add_object_type(data, vocab_type_map):
+	'''Add appropriate type information for an object based on its 'object_type' name'''
+	typestring = data.get('object_type', '')
+	if typestring in vocab_type_map:
+		clsname = vocab_type_map.get(typestring, None)
+		otype = getattr(vocab, clsname)
+		add_crom_data(data=data, what=otype(ident=data['uri']))
+	elif ';' in typestring:
+		parts = [s.strip() for s in typestring.split(';')]
+		if all([s in vocab_type_map for s in parts]):
+			types = [getattr(vocab, vocab_type_map[s]) for s in parts]
+			obj = vocab.make_multitype_obj(*types, ident=data['uri'])
+			add_crom_data(data=data, what=obj)
+		else:
+			warnings.warn(f'*** Not all object types matched for {typestring!r}')
+			add_crom_data(data=data, what=model.HumanMadeObject(ident=data['uri']))
+	else:
+		warnings.warn(f'*** No object type for {typestring!r}')
+		add_crom_data(data=data, what=model.HumanMadeObject(ident=data['uri']))
+
+	parent = data['parent_data']
+	coll_data = parent.get('_lot_object_set')
+	if coll_data:
+		coll = get_crom_object(coll_data)
+		if coll:
+			data['member_of'] = [coll]
+
+	return data
+
+class AddArtists(Configurable):
+	helper = Option(required=True)
+	attribution_modifiers = Service('attribution_modifiers')
+	attribution_group_types = Service('attribution_group_types')
+	make_la_person = Service('make_la_person')
+
+	def __call__(self, data:dict, *, attribution_modifiers, attribution_group_types, make_la_person):
+		'''Add modeling for artists as people involved in the production of an object'''
+		hmo = get_crom_object(data)
+		data['_organizations'] = []
+		data['_original_objects'] = []
+
+		try:
+			hmo_label = f'{hmo._label}'
+		except AttributeError:
+			hmo_label = 'object'
+		event_id = hmo.id + '-Production'
+		event = model.Production(ident=event_id, label=f'Production event for {hmo_label}')
+		hmo.produced_by = event
+
+		artists = data.get('_artists', [])
+
+		sales_record = get_crom_object(data['_record'])
+		pi = self.helper.person_identity
+
+		for a in artists:
+			a.update({
+				'pi_record_no': data['pi_record_no'],
+				'ulan': a['artist_ulan'],
+				'auth_name': a['art_authority'],
+				'name': a['artist_name']
+			})
+
+		def is_or_anon(data:dict):
+			if not pi.is_anonymous(data):
+				return False
+			mods = {m.lower().strip() for m in data.get('attrib_mod_auth', '').split(';')}
+			return 'or' in mods
+		or_anon_records = [is_or_anon(a) for a in artists]
+		uncertain_attribution = any(or_anon_records)
+		for seq_no, a in enumerate(artists):
+			attrib_assignment_classes = [model.AttributeAssignment]
+			if uncertain_attribution:
+				attrib_assignment_classes.append(vocab.PossibleAssignment)
+			if is_or_anon(a):
+				# do not model the "or anonymous" records; they turn into uncertainty on the other records
+				continue
+			pi.add_uri(a, record_id=f'artist-{seq_no+1}')
+			pi.add_names(a, referrer=sales_record, role='artist')
+			artist_label = a.get('role_label')
+			make_la_person(a)
+			person = get_crom_object(a)
+
+			mod = a.get('attrib_mod_auth')
+			if mod:
+				mods = {m.lower().strip() for m in mod.split(';')}
+
+				# TODO: this should probably be in its own JSON service file:
+				STYLE_OF = set(attribution_modifiers['style of'])
+				FORMERLY_ATTRIBUTED_TO = set(attribution_modifiers['formerly attributed to'])
+				ATTRIBUTED_TO = set(attribution_modifiers['attributed to'])
+				COPY_AFTER = set(attribution_modifiers['copy after'])
+				PROBABLY = set(attribution_modifiers['probably by'])
+				POSSIBLY = set(attribution_modifiers['possibly by'])
+				UNCERTAIN = PROBABLY | POSSIBLY
+
+				GROUP_TYPES = set(attribution_group_types.values())
+				GROUP_MODS = {k for k, v in attribution_group_types.items() if v in GROUP_TYPES}
+
+				if 'or' in mods:
+					warnings.warn('Handle OR attribution modifier') # TODO: some way to model this uncertainty?
+
+				if 'copy by' in mods:
+					# equivalent to no modifier
+					pass
+				elif ATTRIBUTED_TO & mods:
+					# equivalent to no modifier
+					pass
+				elif STYLE_OF & mods:
+					assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'In the style of {artist_label}')
+					event.attributed_by = assignment
+					assignment.assigned_property = 'influenced_by'
+					assignment.property_classified_as = vocab.instances['style of']
+					assignment.assigned = person
+					continue
+				elif GROUP_MODS & mods:
+					mod_name = list(GROUP_MODS & mods)[0] # TODO: use all matching types?
+					clsname = attribution_group_types[mod_name]
+					cls = getattr(vocab, clsname)
+					group_label = f'{clsname} of {artist_label}'
+					group_id = a['uri'] + f'-{clsname}'
+					group = cls(ident=group_id, label=group_label)
+					formation = model.Formation(ident='', label=f'Formation of {group_label}')
+					formation.influenced_by = person
+					group.formed_by = formation
+					group_data = add_crom_data({'uri': group_id}, group)
+					data['_organizations'].append(group_data)
+
+					subevent_id = event_id + f'-{seq_no}'
+					subevent = model.Production(ident=subevent_id, label=f'Production sub-event for {group_label}')
+					subevent.carried_out_by = group
+
+					if uncertain_attribution:
+						assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'Possibly attributed to {group_label}')
+						event.attributed_by = assignment
+						assignment.assigned_property = 'part'
+						assignment.assigned = subevent
+					else:
+						event.part = subevent
+					continue
+				elif FORMERLY_ATTRIBUTED_TO & mods:
+					# the {uncertain_attribution} flag does not apply to this branch, because this branch is not making a statement
+					# about a previous attribution. the uncertainty applies only to the current attribution.
+					assignment = vocab.ObsoleteAssignment(ident='', label=f'Formerly attributed to {artist_label}')
+					event.attributed_by = assignment
+					assignment.assigned_property = 'carried_out_by'
+					assignment.assigned = person
+					continue
+				elif UNCERTAIN & mods:
+					if POSSIBLY & mods:
+						attrib_assignment_classes.append(vocab.PossibleAssignment)
+						assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'Possibly attributed to {artist_label}')
+						assignment._label = f'Possibly by {artist_label}'
+					else:
+						attrib_assignment_classes.append(vocab.ProbableAssignment)
+						assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'Probably attributed to {artist_label}')
+						assignment._label = f'Probably by {artist_label}'
+					event.attributed_by = assignment
+					assignment.assigned_property = 'carried_out_by'
+					assignment.assigned = person
+					continue
+				elif COPY_AFTER & mods:
+					# the {uncertain_attribution} flag does not apply to this branch, because this branch is not making a statement
+					# about the artist of the work, but about the artist of the original work that this work is a copy of.
+					cls = type(hmo)
+					original_id = hmo.id + '-Original'
+					original_label = f'Original of {hmo_label}'
+					original_hmo = cls(ident=original_id, label=original_label)
+					original_event_id = original_hmo.id + '-Production'
+					original_event = model.Production(ident=original_event_id, label=f'Production event for {original_label}')
+					original_hmo.produced_by = original_event
+
+					original_subevent_id = original_event_id + f'-{seq_no}'
+					original_subevent = model.Production(ident=original_subevent_id, label=f'Production sub-event for {artist_label}')
+					original_event.part = original_subevent
+					original_subevent.carried_out_by = person
+
+					event.influenced_by = original_hmo
+					data['_original_objects'].append(add_crom_data(data={}, what=original_hmo))
+					continue
+				elif {'or', 'and'} & mods:
+					pass
+				else:
+					print(f'UNHANDLED attrib_mod_auth VALUE: {mods}')
+					pprint.pprint(a)
+					continue
+
+			subevent_id = event_id + f'-{seq_no}'
+			subevent = model.Production(ident=subevent_id, label=f'Production sub-event for {artist_label}')
+			subevent.carried_out_by = person
+			if uncertain_attribution:
+				assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'Possibly attributed to {artist_label}')
+				event.attributed_by = assignment
+				assignment.assigned_property = 'part'
+				assignment.assigned = subevent
+			else:
+				event.part = subevent
+		data['_artists'] = [a for a in artists if not is_or_anon(a)]
+		return data


### PR DESCRIPTION
This splits the sales code in `pipeline.projects.provenance` into:

* pipeline construction and shared code (remains in-place)

and new sub-modules that implement bonobo transformation functions and classes:

* `pipeline.projects.provenance.catalogs`
* `pipeline.projects.provenance.events`
* `pipeline.projects.provenance.lots`
* `pipeline.projects.provenance.objects`
