### PR TITLE
Update label_for_timespan_range to handle truncated time strings

### DIFF
--- a/pipeline/util/__init__.py
+++ b/pipeline/util/__init__.py
@@ -474,8 +474,23 @@ def label_for_timespan_range(begin, end, inclusive=False):
 	if isinstance(end, datetime.datetime):
 		end = end.strftime("%Y-%m-%d")
 
-	from_y, from_m, from_d = map(int, begin.split('-'))
-	to_y, to_m, to_d = map(int, end.split('-'))
+
+	orig_begin = begin
+	orig_end = end
+	if begin.count('-') != 2:
+		if not inclusive:
+			raise Exception(f'truncated date strings must operate in inclusive mode in label_for_timespan_range: {begin}')
+		begin = implode_date(dict(zip(('year', 'month', 'day'), (begin.split('-', 3) + ['', '', ''])[:3])), clamp='begin')
+	if end.count('-') != 2:
+		if not inclusive:
+			raise Exception(f'truncated date strings must operate in inclusive mode in label_for_timespan_range: {end}')
+		end = implode_date(dict(zip(('year', 'month', 'day'), (end.split('-', 3) + ['', '', ''])[:3])), clamp='end' if inclusive else 'eoe')
+	
+	beginparts = list(map(int, begin.split('-')))
+	endparts = list(map(int, end.split('-')))
+
+	from_y, from_m, from_d = beginparts
+	to_y, to_m, to_d = endparts
 	if inclusive:
 		maxday = calendar.monthrange(to_y, to_m)[1]
 		if from_y == to_y and from_m == to_m and from_d == 1 and to_d == maxday:
@@ -485,7 +500,7 @@ def label_for_timespan_range(begin, end, inclusive=False):
 			# 1 year range
 			return str(from_y)
 		else:
-			return f'{begin} to {end}'
+			return f'{orig_begin} to {orig_end}'
 	else:
 		if from_y == to_y and from_m == to_m and from_d == to_d - 1:
 			# 1 day range

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime
 import pipeline.util.cleaners
-from pipeline.util import implode_date
+from pipeline.util import implode_date, label_for_timespan_range
 
 class TestDateCleaners(unittest.TestCase):
 	'''
@@ -82,6 +82,32 @@ class TestDateCleaners(unittest.TestCase):
 		self.assertEqual('1781-09-30', implode_date(bad_day_data, prefix='', clamp='end'))
 		self.assertEqual('1781-10-01', implode_date(bad_day_data, prefix='', clamp='eoe'))
 
+	def test_label_for_timespan_range(self):
+		# single year
+		self.assertEqual(label_for_timespan_range('2004-01-01', '2004-12-31', inclusive=True), '2004')
+		self.assertEqual(label_for_timespan_range('2004-01-01', '2005-01-01', inclusive=False), '2004')
+
+		# single month
+		self.assertEqual(label_for_timespan_range('2004-02-01', '2004-02-29', inclusive=True), '2004-02')
+		self.assertEqual(label_for_timespan_range('2004-02-01', '2004-03-01', inclusive=False), '2004-02')
+
+		# single day
+		self.assertEqual(label_for_timespan_range('2004-02-03', '2004-02-03', inclusive=True), '2004-02-03')
+		self.assertEqual(label_for_timespan_range('2004-02-03', '2004-02-04', inclusive=False), '2004-02-03')
+
+		# multi-day
+		self.assertEqual(label_for_timespan_range('2004-02-25', '2004-03-02', inclusive=True), '2004-02-25 to 2004-03-02')
+		self.assertEqual(label_for_timespan_range('2004-02-25', '2004-03-02', inclusive=False), '2004-02-25 to 2004-03-01')
+
+		# truncated dates, lexical year
+		self.assertEqual(label_for_timespan_range('2004', '2005', inclusive=True), '2004 to 2005')
+		with self.assertRaises(Exception):
+			label_for_timespan_range('2004', '2005', inclusive=False)
+
+		# truncated dates, lexical year-month
+		self.assertEqual(label_for_timespan_range('2004-03', '2004-04', inclusive=True), '2004-03 to 2004-04')
+		with self.assertRaises(Exception):
+			label_for_timespan_range('2004-03', '2004-04', inclusive=False)
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Adds support for labeling inclusive timespans with truncated date strings (and raises an exception for exclusive timespans on truncated date strings).