### PR TITLE
Refactor shared pipeline

### DIFF
--- a/pipeline/io/file.py
+++ b/pipeline/io/file.py
@@ -9,6 +9,7 @@ from bonobo.constants import NOT_MODIFIED
 from bonobo.config import Configurable, Option
 from pipeline.util import ExclusiveValue
 from cromulent import model, reader
+from cromulent.model import factory
 
 def filename_for(data: dict):
 	uu = data.get('uuid')
@@ -104,7 +105,7 @@ class MergingFileWriter(Configurable):
 					return m
 			except model.DataError:
 				print(f'Exception caught while merging data from {fn}:')
-				print(d)
+				print(factory.toString(model_object, False))
 				print(content)
 				raise
 		

--- a/pipeline/projects/__init__.py
+++ b/pipeline/projects/__init__.py
@@ -43,19 +43,11 @@ class StaticInstanceHolder:
 		return used
 
 class PipelineBase:
-	def __init__(self):
+	def __init__(self, *, helper):
 		self.project_name = None
 		self.input_path = None
+		self.helper = helper
 		self.static_instances = StaticInstanceHolder(self.setup_static_instances())
-
-	def make_uri(self, *values):
-		UID_TAG_PREFIX = self.uid_tag_prefix
-		if values:
-			suffix = ','.join([urllib.parse.quote(str(v)) for v in values])
-			return UID_TAG_PREFIX + suffix
-		else:
-			suffix = str(uuid.uuid4())
-			return UID_TAG_PREFIX + suffix
 
 	def setup_static_instances(self):
 		'''
@@ -64,10 +56,10 @@ class PipelineBase:
 		serialize the related Group or Person record for that attribution, even if it does
 		not appear in the source data.
 		'''
-		GETTY_GRI_URI = self.make_uri('ORGANIZATION', 'LOCATION-CODE', 'JPGM')
+		GETTY_GRI_URI = self.helper.make_proj_uri('ORGANIZATION', 'LOCATION-CODE', 'JPGM')
 		lugt_ulan = 500321736
 		gri_ulan = 500115990
-		LUGT_URI = self.make_uri('PERSON', 'ULAN', lugt_ulan)
+		LUGT_URI = self.helper.make_proj_uri('PERSON', 'ULAN', lugt_ulan)
 		gri = model.Group(ident=GETTY_GRI_URI, label='Getty Research Institute')
 		gri.identified_by = vocab.PrimaryName(ident='', content='Getty Research Institute')
 		gri.exact_match = model.BaseResource(ident=f'http://vocab.getty.edu/ulan/{gri_ulan}')

--- a/pipeline/projects/__init__.py
+++ b/pipeline/projects/__init__.py
@@ -141,3 +141,27 @@ class PipelineBase:
 		else:
 			e = pipeline.execution.GraphExecutor(graph, services)
 			e.run()
+
+class UtilityHelper:
+	def __init__(self, project_name):
+		self.project_name = project_name
+		self.proj_prefix = f'tag:getty.edu,2019:digital:pipeline:{project_name}:REPLACE-WITH-UUID#'
+		self.shared_prefix = f'project_nametag:getty.edu,2019:digital:pipeline:REPLACE-WITH-UUID#'
+
+	def make_proj_uri(self, *values):
+		'''Convert a set of identifying `values` into a URI'''
+		if values:
+			suffix = ','.join([urllib.parse.quote(str(v)) for v in values])
+			return self.proj_prefix + suffix
+		else:
+			suffix = str(uuid.uuid4())
+			return self.proj_prefix + suffix
+
+	def make_shared_uri(self, *values):
+		'''Convert a set of identifying `values` into a URI'''
+		if values:
+			suffix = ','.join([urllib.parse.quote(str(v)) for v in values])
+			return self.shared_prefix + suffix
+		else:
+			suffix = str(uuid.uuid4())
+			return self.shared_prefix + suffix

--- a/pipeline/projects/aata.py
+++ b/pipeline/projects/aata.py
@@ -16,12 +16,12 @@ from langdetect import detect
 import urllib.parse
 from datetime import datetime
 import bonobo
-from bonobo.config import Configurable, Option, use
+from bonobo.config import Configurable, Service, Option, use
 from bonobo.constants import NOT_MODIFIED
 
 import settings
 from cromulent import model, vocab
-from pipeline.projects import PipelineBase
+from pipeline.projects import PipelineBase, UtilityHelper
 from pipeline.util import identity, ExtractKeyedValues, MatchingFiles, timespan_from_outer_bounds
 from pipeline.io.file import MultiFileWriter, MergingFileWriter
 # from pipeline.io.arches import ArchesWriter
@@ -47,6 +47,10 @@ variantTitleIdentifier = vocab.Identifier # TODO: aat for variant titles?
 # utility functions
 
 UID_TAG_PREFIX = 'tag:getty.edu,2019:digital:pipeline:aata:REPLACE-WITH-UUID#'
+
+class AATAUtilityHelper(UtilityHelper):
+	def __init__(self, project_name):
+		super().__init__(project_name)
 
 def aata_uri(*values):
 	'''Convert a set of identifying `values` into a URI'''
@@ -84,73 +88,85 @@ def language_object_from_code(code, language_code_map):
 
 # main article chain
 
-def make_aata_journal_dict(e):
-	data = _xml_extract_journal(e)
-	data.update({
-		'object_type': vocab.JournalText,
-	})
-	return data
-
-def make_aata_series_dict(e):
-	data = _xml_extract_series(e)
-	data.update({
-		'object_type': vocab.SeriesText,
-	})
-# 	print(f'SERIES: {pprint.pformat(data)}')
-	return data
-
-def make_publishing_activity(data: dict):
-	lo = get_crom_object(data)
-	components = data['uri_components']
-	pubs = data.get('publishers', [])
-	title = data.get('label')
+class MakeAATAJournalDict(Configurable):
+	helper = Option(required=True)
 	
-	previous_components = data.get('previous', {}).get('uri_components')
-	for pub in pubs:
-		start, end = data['years']
-		uri = aata_uri('AATA', *components, 'Publishing')
-		event = vocab.Publishing(ident=uri, label=f'Publishing event for “{title}”')
-		event.timespan = timespan_from_outer_bounds(start, end)
-		lo.used_for = event
-		if previous_components:
-			# TODO: handle modeling of history_reason field
-			previous_uri = aata_uri('AATA', *previous_components, 'Publishing')
-# 			print(f'*** {uri} ===[continued]==> {previous_uri}')
-			event.continued = vocab.Publishing(ident=previous_uri)
+	def __call__(self, e):
+		data = _xml_extract_journal(e, self.helper)
+		data.update({
+			'object_type': vocab.JournalText,
+		})
+		return data
 
-		if 'events' not in pub:
-			pub['events'] = []
-		pub['events'].append(event)
-	return data
+class MakeAATASeriesDict(Configurable):
+	helper = Option(required=True)
+	
+	def __call__(self, e):
+		data = _xml_extract_series(e, self.helper)
+		data.update({
+			'object_type': vocab.SeriesText,
+		})
+	# 	print(f'SERIES: {pprint.pformat(data)}')
+		return data
 
-@use('language_code_map')
-def make_aata_article_dict(e, language_code_map):
-	'''
-	Given an XML element representing an AATA record, extract information about the
-	"article" (this might be a book, chapter, journal article, etc.) including:
+class MakePublishingActivity(Configurable):
+	helper = Option(default=True)
+	
+	def __call__(self, data:dict):
+		lo = get_crom_object(data)
+		components = data['uri_components']
+		pubs = data.get('publishers', [])
+		title = data.get('label')
+	
+		previous_components = data.get('previous', {}).get('uri_components')
+		for pub in pubs:
+			start, end = data['years']
+			uri = self.helper.make_proj_uri('AATA', *components, 'Publishing')
+			event = vocab.Publishing(ident=uri, label=f'Publishing event for “{title}”')
+			event.timespan = timespan_from_outer_bounds(start, end, inclusive=True)
+			lo.used_for = event
+			if previous_components:
+				# TODO: handle modeling of history_reason field
+				previous_uri = self.helper.make_proj_uri('AATA', *previous_components, 'Publishing')
+	# 			print(f'*** {uri} ===[continued]==> {previous_uri}')
+				event.continued = vocab.Publishing(ident=previous_uri)
 
-	* document type
-	* titles and title translations
-	* organizations and their role (e.g. publisher)
-	* creators and thier role (e.g. author, editor)
-	* abstracts
-	* languages
+			if 'events' not in pub:
+				pub['events'] = []
+			pub['events'].append(event)
+		return data
 
-	This information is returned in a single `dict`.
-	'''
+class MakeAATAArticleDict(Configurable):
+	helper = Option(required=True)
+	language_code_map = Service('language_code_map')
+	
+	def __call__(self, e, language_code_map):
+		'''
+		Given an XML element representing an AATA record, extract information about the
+		"article" (this might be a book, chapter, journal article, etc.) including:
 
-	data = _xml_extract_article(e, language_code_map)
-	aata_id = data['_aata_record_id']
-	organizations = list(_xml_extract_organizations(e, aata_id))
-	authors = list(_xml_extract_authors(e, aata_id))
-	abstracts = list(_xml_extract_abstracts(e, aata_id))
+		* document type
+		* titles and title translations
+		* organizations and their role (e.g. publisher)
+		* creators and thier role (e.g. author, editor)
+		* abstracts
+		* languages
 
-	data.update({
-		'_organizations': list(organizations),
-		'_authors': list(authors),
-		'_abstracts': list(abstracts),
-	})
-	return data
+		This information is returned in a single `dict`.
+		'''
+
+		data = _xml_extract_article(e, language_code_map, self.helper)
+		aata_id = data['_aata_record_id']
+		organizations = list(_xml_extract_organizations(e, aata_id, self.helper))
+		authors = list(_xml_extract_authors(e, aata_id, self.helper))
+		abstracts = list(_xml_extract_abstracts(e, aata_id))
+
+		data.update({
+			'_organizations': list(organizations),
+			'_authors': list(authors),
+			'_abstracts': list(abstracts),
+		})
+		return data
 
 def _gaia_authority_type(code):
 	if code == 'CB':
@@ -170,7 +186,7 @@ def _gaia_authority_type(code):
 	else:
 		raise LookupError
 
-def _xml_extract_sponsor_group(e):
+def _xml_extract_sponsor_group(e, helper):
 	aata_id = e.findtext('./sponsor_id')
 	name = e.findtext('./sponsor_name')
 	geog_id = e.findtext('./auth_geog_id')
@@ -178,7 +194,7 @@ def _xml_extract_sponsor_group(e):
 	country = e.findtext('./sponsor_country')
 	return {
 		'label': name,
-		'uri': aata_uri('AATA', 'Sponsor', aata_id),
+		'uri': helper.make_proj_uri('AATA', 'Sponsor', aata_id),
 		'_aata_record_id': aata_id,
 		'identifiers': [(aata_id, vocab.LocalNumber(ident=''))],
 		'place': {
@@ -192,7 +208,7 @@ def _xml_extract_sponsor_group(e):
 		}
 	}
 
-def _xml_extract_publisher_group(e):
+def _xml_extract_publisher_group(e, helper):
 	aata_id = e.findtext('./auth_corp_id')
 	name = e.findtext('./publisher_name')
 	geog_id = e.findtext('./auth_geog_id')
@@ -200,7 +216,7 @@ def _xml_extract_publisher_group(e):
 	country = e.findtext('./publisher_country')
 	return {
 		'label': name,
-		'uri': aata_uri('AATA', 'Publisher', aata_id),
+		'uri': helper.make_proj_uri('AATA', 'Publisher', aata_id),
 		'_aata_record_id': aata_id,
 		'identifiers': [(aata_id, vocab.LocalNumber(ident=''))],
 		'place': {
@@ -214,7 +230,7 @@ def _xml_extract_publisher_group(e):
 		}
 	}
 
-def _xml_extract_journal(e):
+def _xml_extract_journal(e, helper):
 	'''Extract information about a journal record XML element'''
 	aata_id = e.findtext('./record_desc_group/record_id')
 	title = e.findtext('./journal_group/title')
@@ -228,11 +244,11 @@ def _xml_extract_journal(e):
 	start_year = e.findtext('./journal_group/start_year')
 	cease_year = e.findtext('./journal_group/cease_year')
 	
-	journal_uri = aata_uri('AATA', 'Journal', aata_id)
+	journal_uri = helper.make_proj_uri('AATA', 'Journal', aata_id)
 	issn = [(t.text, vocab.IssnIdentifier(ident='')) for t in e.xpath('./journal_group/issn')]
 
-	publishers = [_xml_extract_publisher_group(p) for p in e.xpath('./publisher_group')]
-	sponsors = [_xml_extract_sponsor_group(p) for p in e.xpath('./sponsor_group')]
+	publishers = [_xml_extract_publisher_group(p, helper) for p in e.xpath('./publisher_group')]
+	sponsors = [_xml_extract_sponsor_group(p, helper) for p in e.xpath('./sponsor_group')]
 
 	issues = []
 	volumes = {}
@@ -255,7 +271,7 @@ def _xml_extract_journal(e):
 			if year:
 				begin = datetime.strptime(ymd_to_datetime(year, month, None, which='begin'), "%Y-%m-%dT%H:%M:%S")
 				end = datetime.strptime(ymd_to_datetime(year, month, None, which='end'), "%Y-%m-%dT%H:%M:%S")
-				ts = timespan_from_outer_bounds(begin, end)
+				ts = timespan_from_outer_bounds(begin, end, inclusive=True)
 				# TODO: attach ts to the issue somehow
 			elif month:
 				print(f'*** Found an issue with sort_month but not sort_year (!?) in record {aata_id}')
@@ -276,7 +292,7 @@ def _xml_extract_journal(e):
 			notes.append(chron)
 		
 		volumes[volume_number] = {
-			'uri': aata_uri('AATA', 'Journal', aata_id, 'Volume', volume_number),
+			'uri': helper.make_proj_uri('AATA', 'Journal', aata_id, 'Volume', volume_number),
 			'object_type': vocab.VolumeText,
 			'label': f'Volume {volume_number} of “{title}”',
 			'_aata_record_id': issue_id,
@@ -287,7 +303,7 @@ def _xml_extract_journal(e):
 			issue_title = f'Issue {issue_number} of “{title}”'
 
 		issues.append({
-			'uri': aata_uri('AATA', 'Journal', aata_id, 'Issue', issue_number),
+			'uri': helper.make_proj_uri('AATA', 'Journal', aata_id, 'Issue', issue_number),
 			'object_type': vocab.IssueText,
 			'label': issue_title,
 			'_aata_record_id': issue_id,
@@ -306,7 +322,7 @@ def _xml_extract_journal(e):
 		history_id = jh.findtext('./linked_journal_id')
 		history_name = jh.findtext('./linked_journal_name')
 		history_reason = jh.findtext('./change_reason')
-		huri = aata_uri('AATA', 'Journal', history_id)
+		huri = helper.make_proj_uri('AATA', 'Journal', history_id)
 		previous = {
 			'uri': huri,
 			'uri_components': ('Journal', history_id),
@@ -336,7 +352,7 @@ def _xml_extract_journal(e):
 	
 	return {k: v for k, v in data.items() if v is not None}
 
-def _xml_extract_series(e):
+def _xml_extract_series(e, helper):
 	'''Extract information about a series record XML element'''
 	aata_id = e.findtext('./record_desc_group/record_id')
 	title = e.findtext('./series_group/title')
@@ -350,17 +366,17 @@ def _xml_extract_series(e):
 	start_year = e.findtext('./series_group/start_year')
 	cease_year = e.findtext('./series_group/cease_year')
 	
-	series_uri = aata_uri('AATA', 'Series', aata_id)
+	series_uri = helper.make_proj_uri('AATA', 'Series', aata_id)
 	issn = [(t.text, vocab.IssnIdentifier(ident='')) for t in e.xpath('./series_group/issn')]
-	publishers = [_xml_extract_publisher_group(p) for p in e.xpath('./publisher_group')]
-	sponsors = [_xml_extract_sponsor_group(p) for p in e.xpath('./sponsor_group')]
+	publishers = [_xml_extract_publisher_group(p, helper) for p in e.xpath('./publisher_group')]
+	sponsors = [_xml_extract_sponsor_group(p, helper) for p in e.xpath('./sponsor_group')]
 
 	previous = None
 	for jh in e.xpath('./series_group/series_history'):
 		history_id = jh.findtext('./linked_series_id')
 		history_name = jh.findtext('./linked_series_name')
 		history_reason = jh.findtext('./change_reason')
-		huri = aata_uri('AATA', 'Series', history_id)
+		huri = helper.make_proj_uri('AATA', 'Series', history_id)
 		previous = {
 			'uri': huri,
 			'uri_components': ('Series', history_id),
@@ -388,7 +404,7 @@ def _xml_extract_series(e):
 	
 	return {k: v for k, v in data.items() if v is not None}
 
-def _xml_extract_article(e, language_code_map):
+def _xml_extract_article(e, language_code_map, helper):
 	'''Extract information about an "article" record XML element'''
 	doc_type = e.findtext('./record_desc_group/doc_type')
 	title = e.findtext('./title_group[title_type = "Analytic"]/title')
@@ -442,7 +458,7 @@ def _xml_extract_article(e, language_code_map):
 		# this is the upward pointing relation between, e.g., chapters and books
 		cid = c.text
 		collective = make_la_lo({
-			'uri': aata_uri('AATA', 'LinguisticObject', cid)
+			'uri': helper.make_proj_uri('AATA', 'LinguisticObject', cid)
 		})
 		part_of.append(collective)
 
@@ -488,7 +504,7 @@ def _xml_extract_article(e, language_code_map):
 		'classifications': classifications,
 		'indexing': indexings,
 		'part_of': part_of,
-		'uri': aata_uri(*id_components),
+		'uri': helper.make_proj_uri(*id_components),
 	}
 
 def _xml_extract_abstracts(e, aata_id):
@@ -513,7 +529,7 @@ def _xml_extract_abstracts(e, aata_id):
 				'identifiers': localIds + legacyIds,
 			}
 
-def _xml_extract_organizations(e, aata_id):
+def _xml_extract_organizations(e, aata_id, helper):
 	'''Extract information about organizations from an "article" record XML element'''
 	i = -1
 	for ig in e.xpath('./imprint_group/related_organization'):
@@ -539,13 +555,13 @@ def _xml_extract_organizations(e, aata_id):
 					'names': [(name,)],
 					'object_type': _gaia_authority_type(auth_type),
 					'identifiers': [vocab.LocalNumber(ident='', content=auth_id)],
-					'uri': aata_uri('AATA', 'Organization', auth_type, auth_id, name),
+					'uri': helper.make_proj_uri('AATA', 'Organization', auth_type, auth_id, name),
 				}
 			else:
 				print('*** No organization_id found for record %s:' % (o,))
 				print(lxml.etree.tostring(o).decode('utf-8'))
 
-def _xml_extract_authors(e, aata_id):
+def _xml_extract_authors(e, aata_id, helper):
 	'''Extract information about authors from an "article" record XML element'''
 	i = -1
 	for ag in e.xpath('./authorship_group'):
@@ -575,7 +591,7 @@ def _xml_extract_authors(e, aata_id):
 						'names': [(name,)],
 						'object_type': _gaia_authority_type(auth_type),
 						'identifiers': [vocab.LocalNumber(ident='', content=auth_id)],
-						'uri': aata_uri(*id_components),
+						'uri': helper.make_proj_uri(*id_components),
 					}
 
 					if role is not None:
@@ -805,53 +821,56 @@ def detect_title_language(data: dict, language_code_map):
 		print('*** detect_title_language error: %r' % (e,))
 	return NOT_MODIFIED
 
-@use('language_code_map')
-def make_aata_abstract(data, language_code_map):
-	'''
-	Given a `dict` representing an "article," extract the abstract records.
-	yield a new `dict`s for each such record.
+class MakeAATAAbstract(Configurable):
+	helper = Option(required=True)
+	language_code_map = Service('language_code_map')
+	
+	def __call__(self, data, language_code_map):
+		'''
+		Given a `dict` representing an "article," extract the abstract records.
+		yield a new `dict`s for each such record.
 
-	The resulting asbtract `dict` will contain these keys:
+		The resulting asbtract `dict` will contain these keys:
 
-	* `_LOD_OBJECT`: A `model.LinguisticObject` object representing the abstract
-	* `_aata_record_id`: The identifier of the corresponding article
-	* `_aata_record_author_seq`: A integer identifying this abstract
-	                             (unique within the scope of the article)
-	* `content`: The text content of the abstract
-	* `language`: A model object representing the declared langauge of the abstract (if any)
-	* `author_abstract_flag`: A boolean value indicating whether the article's authors also
-	                          authored the abstract
-	* `identifiers`: A `list` of (identifier, identifier type) pairs
-	* `_authors`: The authorship information from the input article `dict`
-	* `uid`: A unique ID for this abstract
-	* `parent`: The model object representing the corresponding article
-	* `parent_data`: The `dict` representing the corresponding article
-	'''
-	lod_object = get_crom_object(data)
-	for a in data.get('_abstracts', []):
-		abstract_dict = {k: v for k, v in a.items() if k not in ('language',)}
-		abstract_uri = aata_uri('AATA', 'Abstract', data['_aata_record_id'], a['_aata_record_abstract_seq'])
-		content = a.get('content')
-		abstract = vocab.Abstract(ident=abstract_uri, content=content)
-		abstract.refers_to = lod_object
-		langcode = a.get('language')
-		if langcode is not None:
-			language = language_object_from_code(langcode, language_code_map)
-			if language is not None:
-				abstract.language = language
-				abstract_dict['language'] = language
+		* `_LOD_OBJECT`: A `model.LinguisticObject` object representing the abstract
+		* `_aata_record_id`: The identifier of the corresponding article
+		* `_aata_record_author_seq`: A integer identifying this abstract
+									 (unique within the scope of the article)
+		* `content`: The text content of the abstract
+		* `language`: A model object representing the declared langauge of the abstract (if any)
+		* `author_abstract_flag`: A boolean value indicating whether the article's authors also
+								  authored the abstract
+		* `identifiers`: A `list` of (identifier, identifier type) pairs
+		* `_authors`: The authorship information from the input article `dict`
+		* `uid`: A unique ID for this abstract
+		* `parent`: The model object representing the corresponding article
+		* `parent_data`: The `dict` representing the corresponding article
+		'''
+		lod_object = get_crom_object(data)
+		for a in data.get('_abstracts', []):
+			abstract_dict = {k: v for k, v in a.items() if k not in ('language',)}
+			abstract_uri = self.helper.make_proj_uri('AATA', 'Abstract', data['_aata_record_id'], a['_aata_record_abstract_seq'])
+			content = a.get('content')
+			abstract = vocab.Abstract(ident=abstract_uri, content=content)
+			abstract.refers_to = lod_object
+			langcode = a.get('language')
+			if langcode is not None:
+				language = language_object_from_code(langcode, language_code_map)
+				if language is not None:
+					abstract.language = language
+					abstract_dict['language'] = language
 
-		if '_authors' in data:
-			abstract_dict['_authors'] = data['_authors']
+			if '_authors' in data:
+				abstract_dict['_authors'] = data['_authors']
 
-		# create a uid based on the AATA record id, the sequence number of the abstract
-		# in that record, and which author we're handling right now
-		abstract_dict.update({
-			'parent_data': data,
-			'uri': abstract_uri,
-		})
-		add_crom_data(data=abstract_dict, what=abstract)
-		yield abstract_dict
+			# create a uid based on the AATA record id, the sequence number of the abstract
+			# in that record, and which author we're handling right now
+			abstract_dict.update({
+				'parent_data': data,
+				'uri': abstract_uri,
+			})
+			add_crom_data(data=abstract_dict, what=abstract)
+			yield abstract_dict
 
 def make_issue(data: dict):
 	parent_data = data['parent_data']
@@ -877,14 +896,17 @@ def filter_abstract_authors(data: dict):
 class AATAPipeline(PipelineBase):
 	'''Bonobo-based pipeline for transforming AATA data from XML into JSON-LD.'''
 	def __init__(self, input_path, abstracts_pattern, journals_pattern, series_pattern, **kwargs):
+		project_name = 'aata'
+		helper = AATAUtilityHelper(project_name)
 		self.uid_tag_prefix = UID_TAG_PREFIX
-		super().__init__()
-		
+
+		super().__init__(helper=helper)
+		self.project_name = project_name
+
 		vocab.register_vocab_class('VolumeNumber', {'parent': model.Identifier, 'id': '300265632', 'label': 'Volume'})
 		vocab.register_vocab_class('IssueNumber', {'parent': model.Identifier, 'id': '300312349', 'label': 'Issue'})
 		vocab.register_vocab_class('PublicationPeriodNote', {'parent': model.LinguisticObject, 'id': '300081446', 'label': 'Publication Period Note', 'brief': True})
 
-		self.project_name = 'aata'
 		self.graph = None
 		self.models = kwargs.get('models', {})
 		self.abstracts_pattern = abstracts_pattern
@@ -905,7 +927,7 @@ class AATAPipeline(PipelineBase):
 	def add_articles_chain(self, graph, records, serialize=True):
 		'''Add transformation of article records to the bonobo pipeline.'''
 		articles = graph.add_chain(
-			make_aata_article_dict,
+			MakeAATAArticleDict(helper=self.helper),
 			add_aata_object_type,
 			detect_title_language,
 			MakeLinkedArtLinguisticObject(),
@@ -915,11 +937,15 @@ class AATAPipeline(PipelineBase):
 		)
 		if serialize:
 			# write ARTICLES data
-			self.add_serialization_chain(graph, articles.output)
+			self.add_serialization_chain(graph, articles.output, model=self.models['LinguisticObject'])
 		return articles
 
 	def add_people_chain(self, graph, articles, serialize=True):
 		'''Add transformation of author records to the bonobo pipeline.'''
+		def trace(d):
+			print(get_crom_object(d))
+			return d
+		
 		articles_with_authors = graph.add_chain(
 			add_aata_authors,
 			_input=articles.output
@@ -927,7 +953,7 @@ class AATAPipeline(PipelineBase):
 
 		if serialize:
 			# write ARTICLES with their authorship/creation events data
-			self.add_serialization_chain(graph, articles_with_authors.output)
+			self.add_serialization_chain(graph, articles_with_authors.output, model=self.models['LinguisticObject'])
 
 		people = graph.add_chain(
 			ExtractKeyedValues(key='_authors'),
@@ -942,7 +968,7 @@ class AATAPipeline(PipelineBase):
 		'''Add transformation of abstract records to the bonobo pipeline.'''
 		model_id = self.models.get('LinguisticObject', 'XXX-LinguisticObject-Model')
 		abstracts = graph.add_chain(
-			make_aata_abstract,
+			MakeAATAAbstract(helper=self.helper),
 			AddArchesModel(model=self.models['LinguisticObject']),
 			MakeLinkedArtAbstract(),
 			_input=articles.output
@@ -957,7 +983,7 @@ class AATAPipeline(PipelineBase):
 
 		if serialize:
 			# write ABSTRACTS data
-			self.add_serialization_chain(graph, abstracts.output)
+			self.add_serialization_chain(graph, abstracts.output, model=self.models['LinguisticObject'])
 		return abstracts
 
 	def add_organizations_chain(self, graph, articles, key='organizations', serialize=True):
@@ -999,9 +1025,9 @@ class AATAPipeline(PipelineBase):
 		journals = graph.add_chain(
 			MatchingFiles(path='/', pattern=self.journals_pattern, fs='fs.data.aata'),
 			CurriedXMLReader(xpath='/journal_XML/record', fs='fs.data.aata', limit=self.limit),
-			make_aata_journal_dict,
+			MakeAATAJournalDict(helper=self.helper),
 			MakeLinkedArtLinguisticObject(),
-			make_publishing_activity,
+			MakePublishingActivity(helper=self.helper),
 			# Trace(name='journal', ordinals=list(range(100)))
 		)
 		
@@ -1018,9 +1044,9 @@ class AATAPipeline(PipelineBase):
 		series = graph.add_chain(
 			MatchingFiles(path='/', pattern=self.series_pattern, fs='fs.data.aata'),
 			CurriedXMLReader(xpath='/series_XML/record', fs='fs.data.aata', limit=self.limit),
-			make_aata_series_dict,
+			MakeAATASeriesDict(helper=self.helper),
 			MakeLinkedArtLinguisticObject(),
-			make_publishing_activity,
+			MakePublishingActivity(helper=self.helper),
 # 			Trace(name='series')
 		)
 

--- a/pipeline/projects/aata.py
+++ b/pipeline/projects/aata.py
@@ -52,15 +52,6 @@ class AATAUtilityHelper(UtilityHelper):
 	def __init__(self, project_name):
 		super().__init__(project_name)
 
-def aata_uri(*values):
-	'''Convert a set of identifying `values` into a URI'''
-	if values:
-		suffix = ','.join([urllib.parse.quote(str(v)) for v in values])
-		return UID_TAG_PREFIX + suffix
-	else:
-		suffix = str(uuid.uuid4())
-		return UID_TAG_PREFIX + suffix
-
 def language_object_from_code(code, language_code_map):
 	'''
 	Given a three-letter language code (which are mostly drawn from ISO639-2, with some

--- a/pipeline/projects/provenance/__init__.py
+++ b/pipeline/projects/provenance/__init__.py
@@ -167,8 +167,8 @@ class ProvenanceUtilityHelper(UtilityHelper):
 	'''
 	Project-specific code for accessing and interpreting sales data.
 	'''
-	def __init__(self):
-		super().__init__('provenance')
+	def __init__(self, project_name):
+		super().__init__(project_name)
 		# TODO: does this handle all the cases of data packed into the lot_number string that need to be stripped?
 		self.shared_lot_number_re = re.compile(r'(\[[a-z]\])')
 		self.ignore_house_authnames = CaseFoldingSet(('Anonymous',))
@@ -296,6 +296,8 @@ class TrackLotSizes(Configurable):
 class ProvenancePipeline(PipelineBase):
 	'''Bonobo-based pipeline for transforming Provenance data from CSV into JSON-LD.'''
 	def __init__(self, input_path, catalogs, auction_events, contents, **kwargs):
+		project_name = 'provenance'
+		helper = ProvenanceUtilityHelper(project_name)
 		self.uid_tag_prefix = UID_TAG_PREFIX
 
 		vocab.register_instance('fire', {'parent': model.Type, 'id': '300068986', 'label': 'Fire'})
@@ -303,9 +305,8 @@ class ProvenancePipeline(PipelineBase):
 		vocab.register_instance('history', {'parent': model.Type, 'id': '300033898', 'label': 'History'})
 		vocab.register_vocab_class('AuctionCatalog', {'parent': model.HumanMadeObject, 'id': '300026068', 'label': 'Auction Catalog', 'metatype': 'work type'})
 
-		super().__init__()
-		self.project_name = 'provenance'
-		self.helper = ProvenanceUtilityHelper()
+		super().__init__(helper=helper)
+		self.project_name = project_name
 
 		self.graph_0 = None
 		self.graph_1 = None

--- a/pipeline/projects/provenance/__init__.py
+++ b/pipeline/projects/provenance/__init__.py
@@ -38,7 +38,7 @@ from cromulent.model import factory
 from cromulent.extract import extract_physical_dimensions, extract_monetary_amount
 
 import pipeline.execution
-from pipeline.projects import PipelineBase
+from pipeline.projects import PipelineBase, UtilityHelper
 from pipeline.projects.provenance.util import *
 from pipeline.util import \
 			GraphListSource, \
@@ -75,8 +75,8 @@ class PersonIdentity:
 	'''
 	Utility class to help assign records for people with properties such as `uri` and identifiers.
 	'''
-	def __init__(self, make_uri=None):
-		self.make_uri = make_uri or pir_uri
+	def __init__(self, *, make_uri):
+		self.make_uri = make_uri
 		self.ignore_authnames = CaseFoldingSet(('NEW', 'NON-UNIQUE'))
 
 	def acceptable_auth_name(self, auth_name):
@@ -163,17 +163,18 @@ class PersonIdentity:
 		if role:
 			data['role_label'] = role_label
 
-class ProvenanceUtilityHelper:
+class ProvenanceUtilityHelper(UtilityHelper):
 	'''
 	Project-specific code for accessing and interpreting sales data.
 	'''
 	def __init__(self):
+		super().__init__('provenance')
 		# TODO: does this handle all the cases of data packed into the lot_number string that need to be stripped?
 		self.shared_lot_number_re = re.compile(r'(\[[a-z]\])')
 		self.ignore_house_authnames = CaseFoldingSet(('Anonymous',))
 		self.csv_source_columns = ['pi_record_no', 'catalog_number']
 		self.problematic_record_uri = 'tag:getty.edu,2019:digital:pipeline:provenance:ProblematicRecord'
-		self.person_identity = PersonIdentity()
+		self.person_identity = PersonIdentity(make_uri=self.make_proj_uri)
 		self.uid_tag_prefix = UID_TAG_PREFIX
 
 	def copy_source_information(self, dst: dict, src: dict):
@@ -182,14 +183,13 @@ class ProvenanceUtilityHelper:
 				dst[k] = src[k]
 		return dst
 
-	@staticmethod
-	def auction_event_for_catalog_number(catalog_number):
+	def auction_event_for_catalog_number(self, catalog_number):
 		'''
 		Return a `vocab.AuctionEvent` object and its associated 'uid' key and URI, based on
 		the supplied `catalog_number`.
 		'''
 		uid = f'AUCTION-EVENT-CATALOGNUMBER-{catalog_number}'
-		uri = pir_uri('AUCTION-EVENT', 'CATALOGNUMBER', catalog_number)
+		uri = self.make_proj_uri('AUCTION-EVENT', 'CATALOGNUMBER', catalog_number)
 		auction = vocab.AuctionEvent(ident=uri)
 		auction._label = f"Auction Event for {catalog_number}"
 		return auction, uid, uri
@@ -220,8 +220,8 @@ class ProvenanceUtilityHelper:
 		for p in prices:
 			n = p.get('price_note')
 			if n and n.startswith('for lots '):
-				return pir_uri('AUCTION-TX-MULTI', cno, date, n[9:])
-		return pir_uri('AUCTION-TX', cno, date, shared_lot_number)
+				return self.make_proj_uri('AUCTION-TX-MULTI', cno, date, n[9:])
+		return self.make_proj_uri('AUCTION-TX', cno, date, shared_lot_number)
 
 	def lots_in_transaction(self, data, prices):
 		'''
@@ -243,7 +243,7 @@ class ProvenanceUtilityHelper:
 		'''
 		shared_lot_number = self.shared_lot_number_from_lno(lno)
 		uid = f'AUCTION-{cno}-LOT-{shared_lot_number}-DATE-{date}'
-		uri = pir_uri('AUCTION', cno, 'LOT', shared_lot_number, 'DATE', date)
+		uri = self.make_proj_uri('AUCTION', cno, 'LOT', shared_lot_number, 'DATE', date)
 		return uid, uri
 
 	@staticmethod
@@ -364,9 +364,9 @@ class ProvenancePipeline(PipelineBase):
 	def add_physical_catalogs_chain(self, graph, records, serialize=True):
 		'''Add modeling of physical copies of auction catalogs.'''
 		catalogs = graph.add_chain(
-			pipeline.projects.provenance.catalogs.add_auction_catalog,
-			pipeline.projects.provenance.catalogs.add_physical_catalog_objects,
-			pipeline.projects.provenance.catalogs.add_physical_catalog_owners,
+			pipeline.projects.provenance.catalogs.AddAuctionCatalog(helper=self.helper),
+			pipeline.projects.provenance.catalogs.AddPhysicalCatalogObjects(helper=self.helper),
+			pipeline.projects.provenance.catalogs.AddPhysicalCatalogOwners(helper=self.helper),
 			_input=records.output
 		)
 		if serialize:
@@ -423,7 +423,7 @@ class ProvenancePipeline(PipelineBase):
 							'specific_loc')},
 				}
 			),
-			pipeline.projects.provenance.catalogs.add_auction_catalog,
+			pipeline.projects.provenance.catalogs.AddAuctionCatalog(helper=self.helper),
 			pipeline.projects.provenance.events.AddAuctionEvent(helper=self.helper),
 			pipeline.projects.provenance.events.AddAuctionHouses(helper=self.helper),
 			pipeline.projects.provenance.events.PopulateAuctionEvent(helper=self.helper),
@@ -637,7 +637,7 @@ class ProvenancePipeline(PipelineBase):
 						'lot_sale_mod',
 						'lot_notes')},
 				'_object': {
-					'postprocess': add_pir_object_uri,
+					'postprocess': add_pir_object_uri_factory(self.helper),
 					'properties': (
 						'title',
 						'title_modifier',
@@ -928,8 +928,8 @@ class ProvenancePipeline(PipelineBase):
 # 		print('Rewrite output files, replacing the following URIs:')
 		for src, dst in g:
 			canonical, steps = g.canonical_key(src)
-			src_uri = pir_uri('OBJECT', *src)
-			dst_uri = pir_uri('OBJECT', *canonical)
+			src_uri = self.helper.make_proj_uri('OBJECT', *src)
+			dst_uri = self.helper.make_proj_uri('OBJECT', *canonical)
 # 			print(f's/ {src_uri:<100} / {dst_uri:<100} /')
 			post_sale_rewrite_map[src_uri] = dst_uri
 			if canonical in large_components:

--- a/pipeline/projects/provenance/events.py
+++ b/pipeline/projects/provenance/events.py
@@ -7,7 +7,6 @@ from bonobo.config import Option, Service, Configurable
 from cromulent import model, vocab
 
 import pipeline.execution
-from pipeline.projects.provenance.util import pir_uri
 from pipeline.util import implode_date, timespan_from_outer_bounds
 from pipeline.util.cleaners import parse_location
 import pipeline.linkedart
@@ -27,7 +26,7 @@ class AddAuctionEvent(Configurable):
 		add_crom_data(data=data, what=auction)
 		catalog = get_crom_object(data['_catalog'])
 
-		record_uri = pir_uri('AUCTION-EVENT', 'CATALOGNUMBER', cno, 'RECORD')
+		record_uri = self.helper.make_proj_uri('AUCTION-EVENT', 'CATALOGNUMBER', cno, 'RECORD')
 		label = f'Record of auction event from catalog {cno}'
 		record = model.LinguisticObject(ident=record_uri, label=label) # TODO: needs classification
 		record_data	= {'uri': record_uri}
@@ -69,7 +68,7 @@ class PopulateAuctionEvent(Configurable):
 		# make_la_place is called here instead of as a separate graph node because the Place object
 		# gets stored in the `auction_locations` object to be used in the second graph component
 		# which uses the data to associate the place with auction lots.
-		base_uri = pir_uri('AUCTION-EVENT', 'CATALOGNUMBER', cno, 'PLACE')
+		base_uri = self.helper.make_proj_uri('AUCTION-EVENT', 'CATALOGNUMBER', cno, 'PLACE')
 		place_data = pipeline.linkedart.make_la_place(current, base_uri=base_uri)
 		place = get_crom_object(place_data)
 		if place:
@@ -120,18 +119,18 @@ class AddAuctionHouses(Configurable):
 		if ulan:
 			key = f'AUCTION-HOUSE-ULAN-{ulan}'
 			a['uid'] = key
-			a['uri'] = pir_uri('AUCTION-HOUSE', 'ULAN', ulan)
+			a['uri'] = self.helper.make_proj_uri('AUCTION-HOUSE', 'ULAN', ulan)
 			a['ulan'] = ulan
 			house = vocab.AuctionHouseOrg(ident=a['uri'])
 		elif auth_name and auth_name not in self.helper.ignore_house_authnames:
-			a['uri'] = pir_uri('AUCTION-HOUSE', 'AUTHNAME', auth_name)
+			a['uri'] = self.helper.make_proj_uri('AUCTION-HOUSE', 'AUTHNAME', auth_name)
 			pname = vocab.PrimaryName(ident='', content=auth_name)
 			pname.referred_to_by = event_record
 			a['identifiers'].append(pname)
 			house = vocab.AuctionHouseOrg(ident=a['uri'])
 		else:
 			# not enough information to identify this house uniquely, so use the source location in the input file
-			a['uri'] = pir_uri('AUCTION-HOUSE', 'CAT_NO', 'CATALOG-NUMBER', a['catalog_number'])
+			a['uri'] = self.helper.make_proj_uri('AUCTION-HOUSE', 'CAT_NO', 'CATALOG-NUMBER', a['catalog_number'])
 			house = vocab.AuctionHouseOrg(ident=a['uri'])
 
 		name = a.get('auc_house_name') or a.get('name')

--- a/pipeline/projects/provenance/objects.py
+++ b/pipeline/projects/provenance/objects.py
@@ -9,7 +9,6 @@ from cromulent import model, vocab
 from cromulent.extract import extract_physical_dimensions
 
 import pipeline.execution
-from pipeline.projects.provenance.util import pir_uri
 from pipeline.util import implode_date, timespan_from_outer_bounds
 from pipeline.util.cleaners import \
 			parse_location_name, \
@@ -100,12 +99,11 @@ class PopulateObject(Configurable):
 		data['_visual_item'] = add_crom_data(data=vidata, what=vi)
 		hmo.shows = vi
 
-	@staticmethod
-	def _populate_object_catalog_record(data:dict, parent, lot, cno, rec_num):
-		catalog_uri = pir_uri('CATALOG', cno)
+	def _populate_object_catalog_record(self, data:dict, parent, lot, cno, rec_num):
+		catalog_uri = self.helper.make_proj_uri('CATALOG', cno)
 		catalog = vocab.AuctionCatalogText(ident=catalog_uri)
 
-		record_uri = pir_uri('CATALOG', cno, 'RECORD', rec_num)
+		record_uri = self.helper.make_proj_uri('CATALOG', cno, 'RECORD', rec_num)
 		lot_object_id = parent['lot_object_id']
 		record = model.LinguisticObject(ident=record_uri, label=f'Sale recorded in catalog: {lot_object_id} (record number {rec_num})') # TODO: needs classification
 		record_data	= {'uri': record_uri}
@@ -172,13 +170,13 @@ class PopulateObject(Configurable):
 							ulan = int(location.get('insi'))
 						if ulan:
 							owner_data['ulan'] = ulan
-							owner_data['uri'] = pir_uri('ORGANIZATION', 'ULAN', ulan)
+							owner_data['uri'] = self.helper.make_proj_uri('ORGANIZATION', 'ULAN', ulan)
 						else:
-							owner_data['uri'] = pir_uri('ORGANIZATION', 'NAME', inst, 'PLACE', loc)
+							owner_data['uri'] = self.helper.make_proj_uri('ORGANIZATION', 'NAME', inst, 'PLACE', loc)
 					else:
 						owner_data = {
 							'label': '(Anonymous organization)',
-							'uri': pir_uri('ORGANIZATION', 'PRESENT-OWNER', *now_key),
+							'uri': self.helper.make_proj_uri('ORGANIZATION', 'PRESENT-OWNER', *now_key),
 						}
 
 					base_uri = hmo.id + '-Place,'
@@ -204,7 +202,7 @@ class PopulateObject(Configurable):
 			hand_note_content = note['hand_note']
 			owner = note.get('hand_note_so')
 			cno = parent['auction_of_lot']['catalog_number']
-			catalog_uri = pir_uri('CATALOG', cno, owner, None)
+			catalog_uri = self.helper.make_proj_uri('CATALOG', cno, owner, None)
 			catalogs = unique_catalogs.get(catalog_uri)
 			note = vocab.Note(ident='', content=hand_note_content)
 			hmo.referred_to_by = note

--- a/tests/test_pir_modeling_attrib_mod.py
+++ b/tests/test_pir_modeling_attrib_mod.py
@@ -10,7 +10,6 @@ import inspect
 from pathlib import Path
 import warnings
 
-from pipeline.projects.provenance.util import pir_uri
 from tests import TestProvenancePipelineOutput
 from cromulent import vocab
 

--- a/tests/test_pir_modeling_buy_sell_mod.py
+++ b/tests/test_pir_modeling_buy_sell_mod.py
@@ -10,7 +10,6 @@ import inspect
 from pathlib import Path
 import warnings
 
-from pipeline.projects.provenance.util import pir_uri
 from tests import TestProvenancePipelineOutput
 from cromulent import vocab
 

--- a/tests/test_pir_modeling_multiartist.py
+++ b/tests/test_pir_modeling_multiartist.py
@@ -10,7 +10,6 @@ import inspect
 from pathlib import Path
 import warnings
 
-from pipeline.projects.provenance.util import pir_uri
 from tests import TestProvenancePipelineOutput
 from cromulent import vocab
 

--- a/tests/test_pir_modeling_or_anon_modifer.py
+++ b/tests/test_pir_modeling_or_anon_modifer.py
@@ -10,7 +10,6 @@ import inspect
 from pathlib import Path
 import warnings
 
-from pipeline.projects.provenance.util import pir_uri
 from tests import TestProvenancePipelineOutput
 from cromulent import vocab
 


### PR DESCRIPTION
This refactors more code, primarily centralizing the generation of the tag: URIs to be a part of the injected helper objects (`ProvenanceUtilityHelper` and `AATAUtilityHelper`).