### PR TITLE
Sub-production merging

### DIFF
--- a/pipeline/projects/__init__.py
+++ b/pipeline/projects/__init__.py
@@ -140,10 +140,13 @@ class UtilityHelper:
 		self.proj_prefix = f'tag:getty.edu,2019:digital:pipeline:{project_name}:REPLACE-WITH-UUID#'
 		self.shared_prefix = f'project_nametag:getty.edu,2019:digital:pipeline:REPLACE-WITH-UUID#'
 
+	def make_uri_path(self, *values):
+		return ','.join([urllib.parse.quote(str(v)) for v in values])
+
 	def make_proj_uri(self, *values):
 		'''Convert a set of identifying `values` into a URI'''
 		if values:
-			suffix = ','.join([urllib.parse.quote(str(v)) for v in values])
+			suffix = self.make_uri_path(*values)
 			return self.proj_prefix + suffix
 		else:
 			suffix = str(uuid.uuid4())
@@ -152,7 +155,7 @@ class UtilityHelper:
 	def make_shared_uri(self, *values):
 		'''Convert a set of identifying `values` into a URI'''
 		if values:
-			suffix = ','.join([urllib.parse.quote(str(v)) for v in values])
+			suffix = self.make_uri_path(*values)
 			return self.shared_prefix + suffix
 		else:
 			suffix = str(uuid.uuid4())

--- a/pipeline/projects/provenance/__init__.py
+++ b/pipeline/projects/provenance/__init__.py
@@ -123,6 +123,7 @@ class PersonIdentity:
 
 	def add_uri(self, data:dict, **kwargs):
 		keys = self.uri_keys(data, **kwargs)
+		data['uri_keys'] = keys
 		data['uri'] = self.make_uri(*keys)
 
 	def add_names(self, data:dict, referrer=None, role=None):

--- a/pipeline/projects/provenance/objects.py
+++ b/pipeline/projects/provenance/objects.py
@@ -414,7 +414,7 @@ class AddArtists(Configurable):
 					group_data = add_crom_data({'uri': group_id}, group)
 					data['_organizations'].append(group_data)
 
-					subevent_id = event_id + f'-{seq_no}'
+					subevent_id = event_id + f'-{seq_no}' # TODO: fix for the case of post-sales merging
 					subevent = model.Production(ident=subevent_id, label=f'Production sub-event for {group_label}')
 					subevent.carried_out_by = group
 
@@ -458,7 +458,7 @@ class AddArtists(Configurable):
 					original_event = model.Production(ident=original_event_id, label=f'Production event for {original_label}')
 					original_hmo.produced_by = original_event
 
-					original_subevent_id = original_event_id + f'-{seq_no}'
+					original_subevent_id = original_event_id + f'-{seq_no}' # TODO: fix for the case of post-sales merging
 					original_subevent = model.Production(ident=original_subevent_id, label=f'Production sub-event for {artist_label}')
 					original_event.part = original_subevent
 					original_subevent.carried_out_by = person
@@ -473,7 +473,8 @@ class AddArtists(Configurable):
 					pprint.pprint(a)
 					continue
 
-			subevent_id = event_id + f'-{seq_no}'
+			subprod_path = self.helper.make_uri_path(*a["uri_keys"])
+			subevent_id = event_id + f'-{subprod_path}'
 			subevent = model.Production(ident=subevent_id, label=f'Production sub-event for {artist_label}')
 			subevent.carried_out_by = person
 			if uncertain_attribution:

--- a/pipeline/projects/provenance/util.py
+++ b/pipeline/projects/provenance/util.py
@@ -63,17 +63,6 @@ def add_pir_object_uri(data, parent, helper):
 	data['uri'] = object_uri(parent, helper)
 	return data
 
-def prev_post_sales_rewrite_map(map_data):
-	post_sale_rewrite_map = map_data.copy()
-	also_rewrite = {}
-	also_rewrite_suffixes = ['Production', 'Destruction', 'VisualItem', 'Original', 'Original-Production', 'Original-Production-1']
-	also_rewrite_suffixes += [f'Production-{i}' for i in range(6)]
-	for k, v in post_sale_rewrite_map.items():
-		for suffix in also_rewrite_suffixes:
-			also_rewrite[f'{k}-{suffix}'] = f'{v}-{suffix}'
-	post_sale_rewrite_map.update(also_rewrite)
-	return post_sale_rewrite_map
-
 class SalesTree:
 	'''
 	This class is used to represent the repeated sales of objects in provenance data.

--- a/pipeline/util/rewriting.py
+++ b/pipeline/util/rewriting.py
@@ -95,13 +95,22 @@ def _rewrite_output_files(files, r, update_filename=False, **kwargs):
 		print(f'{i} files rewritten')
 
 class JSONValueRewriter:
-	def __init__(self, mapping):
+	def __init__(self, mapping, prefix=False):
 		self.mapping = mapping
+		self.prefix = prefix
 
 	def rewrite(self, d, *args, **kwargs):
 		with suppress(TypeError):
 			if d in self.mapping:
 				return self.mapping[d]
+			if self.prefix:
+				if isinstance(d, str):
+					prefixes = [k for k in self.mapping if len(k) < len(d) and k == d[:len(k)]]
+					if prefixes:
+						k = prefixes[0]
+						replace = self.mapping[k]
+						updated = replace + d[len(replace):]
+						return updated
 		if isinstance(d, dict):
 			return {k: self.rewrite(v, *args, **kwargs) for k, v in d.items()}
 		elif isinstance(d, list):

--- a/scripts/remove_meaningless_ids.py
+++ b/scripts/remove_meaningless_ids.py
@@ -11,7 +11,6 @@ from contextlib import suppress
 
 from settings import output_file_path
 from pipeline.util.rewriting import rewrite_output_files, JSONValueRewriter
-from pipeline.projects.provenance.util import prev_post_sales_rewrite_map
 
 class JSONIDRemovalRewriter:
 	def __init__(self):

--- a/scripts/rewrite_post_sales_uris.py
+++ b/scripts/rewrite_post_sales_uris.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 from settings import output_file_path
 from pipeline.util.rewriting import rewrite_output_files, JSONValueRewriter
-from pipeline.projects.provenance.util import prev_post_sales_rewrite_map
 
 if len(sys.argv) < 2:
 	cmd = sys.argv[0]
@@ -24,9 +23,8 @@ print(f'Rewriting post-sales URIs ...')
 rewrite_map_filename = sys.argv[1]
 with open(rewrite_map_filename, 'r') as f:
 	post_sale_rewrite_map = json.load(f)
-	post_sale_rewrite_map = prev_post_sales_rewrite_map(post_sale_rewrite_map)
 # 	print('Post sales rewrite map:')
 # 	pprint.pprint(post_sale_rewrite_map)
-	r = JSONValueRewriter(post_sale_rewrite_map)
+	r = JSONValueRewriter(post_sale_rewrite_map, prefix=True)
 	rewrite_output_files(r, parallel=True)
 print('Done')

--- a/tests/test_pir_modeling_prevsale_merge.py
+++ b/tests/test_pir_modeling_prevsale_merge.py
@@ -14,7 +14,6 @@ from cromulent.model import factory
 
 from pipeline.util import CromObjectMerger
 from pipeline.util.rewriting import JSONValueRewriter
-from pipeline.projects.provenance.util import prev_post_sales_rewrite_map
 from tests import TestProvenancePipelineOutput
 from cromulent import vocab
 
@@ -23,7 +22,7 @@ vocab.add_attribute_assignment_check()
 class PIRModelingTest_PrevSaleMerge(TestProvenancePipelineOutput):
 	def merge_objects(self, objects):
 		rewrite_map_data = self.prev_post_sales_map
-		post_sale_rewrite_map = prev_post_sales_rewrite_map(rewrite_map_data)
+		post_sale_rewrite_map = rewrite_map_data
 		r = JSONValueRewriter(post_sale_rewrite_map)
 		for k in list(objects.keys()):
 			data = objects[k]


### PR DESCRIPTION
Ensure that modeling of per-artist production events supports proper merging when objects are reconciled base don prev/post-sales data. This is done by assigning the production sub-event URIs based on the combination of the super-event URI and The URI components of the artist record (previously a sequential number had been used in place of the artist's data).