### PR TITLE
Add recursive modeling of owner locations.

### DIFF
--- a/pipeline/projects/provenance/__init__.py
+++ b/pipeline/projects/provenance/__init__.py
@@ -492,17 +492,13 @@ class ProvenancePipeline(PipelineBase):
 			ExtractKeyedValue(key='_bidding'),
 			_input=bid_acqs.output
 		)
-		places = graph.add_chain(
-			ExtractKeyedValues(key='_owner_locations'),
-			_input=bid_acqs.output
-		)
+		_ = self.add_places_chain(graph, bid_acqs, key='_owner_locations', serialize=True)
 
 		if serialize:
 			# write SALES data
 			self.add_serialization_chain(graph, refs.output, model=self.models['LinguisticObject'])
 			self.add_serialization_chain(graph, bids.output, model=self.models['Bidding'])
 			self.add_serialization_chain(graph, orgs.output, model=self.models['Group'])
-			self.add_serialization_chain(graph, places.output, model=self.models['Place'])
 		return bid_acqs
 
 	def add_sales_chain(self, graph, records, services, serialize=True):
@@ -751,10 +747,10 @@ class ProvenancePipeline(PipelineBase):
 			self.add_serialization_chain(graph, sets.output, model=self.models['Set'])
 		return sets
 
-	def add_places_chain(self, graph, auction_events, serialize=True):
+	def add_places_chain(self, graph, auction_events, key='_locations', serialize=True):
 		'''Add extraction and serialization of locations.'''
 		places = graph.add_chain(
-			ExtractKeyedValues(key='_locations'),
+			ExtractKeyedValues(key=key),
 			RecursiveExtractKeyedValue(key='part_of'),
 			_input=auction_events.output
 		)


### PR DESCRIPTION
Most `Place` data was already handling the recursive extraction and serialization of broader place data (e.g. "London" to "United Kingdom"). This adds the same treatment to the pipeline graph for owner locations.