### PR TITLE
Add note to objects when there is prev/post sale without a catalog

### DIFF
--- a/pipeline/projects/provenance/objects.py
+++ b/pipeline/projects/provenance/objects.py
@@ -220,6 +220,7 @@ class PopulateObject(Configurable):
 			hmo.referred_to_by = vocab.InscriptionStatement(ident='', content=inscription)
 
 	def _populate_object_prev_post_sales(self, data:dict, this_key, post_sale_map):
+		hmo = get_crom_object(data)
 		post_sales = data.get('post_sale', [])
 		prev_sales = data.get('prev_sale', [])
 		prev_post_sales_records = [(post_sales, False), (prev_sales, True)]
@@ -230,13 +231,18 @@ class PopulateObject(Configurable):
 				plot = self.helper.shared_lot_number_from_lno(plno)
 				pdate = implode_date(sale_record, '')
 				if pcno and plot and pdate:
-					that_key = (pcno, plot, pdate)
-					if rev:
-						# `that_key` is for a previous sale for this object
-						post_sale_map[this_key] = that_key
+					if pcno == 'NA':
+						desc = f'Also sold in an unidentified sale: {plot} ({pdate})'
+						note = vocab.Note(ident='', content=desc)
+						hmo.referred_to_by = note
 					else:
-						# `that_key` is for a later sale for this object
-						post_sale_map[that_key] = this_key
+						that_key = (pcno, plot, pdate)
+						if rev:
+							# `that_key` is for a previous sale for this object
+							post_sale_map[this_key] = that_key
+						else:
+							# `that_key` is for a later sale for this object
+							post_sale_map[that_key] = this_key
 
 	def __call__(self, data:dict, post_sale_map, unique_catalogs, vocab_instance_map, destruction_types_map):
 		'''Add modeling for an object described by a sales record'''


### PR DESCRIPTION
This is based on updates in the sales STAR export data that now includes the sentinel
value `NA` for prev/post sale catalog numbers that do not reference catalogs in the
sales dataset. An example record with this sort of data is:

	Br-4091 lot 0030 (1833-05-10)