### PR TITLE
Add modeling of the persistent_puid field as a GRI-assigned LocalNumber.

### DIFF
--- a/pipeline/projects/__init__.py
+++ b/pipeline/projects/__init__.py
@@ -51,6 +51,7 @@ class PipelineBase:
 		self.helper = helper
 		self.static_instances = StaticInstanceHolder(self.setup_static_instances())
 		helper.add_services(self.get_services())
+		helper.add_static_instances(self.static_instances)
 
 	def setup_static_instances(self):
 		'''
@@ -159,6 +160,9 @@ class UtilityHelper:
 		'''
 		self.services = services
 
+	def add_static_instances(self, static_instances):
+		self.static_instances = static_instances
+
 	def make_uri_path(self, *values):
 		return ','.join([urllib.parse.quote(str(v)) for v in values])
 
@@ -234,3 +238,12 @@ class UtilityHelper:
 			p.part_of = parent
 			data['part_of'] = parent_data
 		return add_crom_data(data=data, what=p)
+
+	def gri_number_id(self, content, id_class=None):
+		if id_class is None:
+			id_class = vocab.LocalNumber
+		catalog_id = id_class(ident='', content=content)
+		assignment = model.AttributeAssignment(ident='')
+		assignment.carried_out_by = self.static_instances.get_instance('Group', 'gri')
+		catalog_id.assigned_by = assignment
+		return catalog_id

--- a/pipeline/projects/provenance/__init__.py
+++ b/pipeline/projects/provenance/__init__.py
@@ -482,7 +482,6 @@ class ProvenanceUtilityHelper(UtilityHelper):
 		add_crom_data(data=a, what=house)
 		return a
 
-
 def add_crom_price(data, parent, services, add_citations=False):
 	'''
 	Add modeling data for `MonetaryAmount`, `StartingPrice`, or `EstimatedPrice`,
@@ -585,7 +584,7 @@ class ProvenancePipeline(PipelineBase):
 		'''Add modeling of auction catalogs as linguistic objects.'''
 		los = graph.add_chain(
 			ExtractKeyedValue(key='_catalog'),
-			pipeline.projects.provenance.catalogs.PopulateAuctionCatalog(static_instances=self.static_instances),
+			pipeline.projects.provenance.catalogs.PopulateAuctionCatalog(helper=self.helper, static_instances=self.static_instances),
 			_input=events.output
 		)
 		if serialize:

--- a/pipeline/projects/provenance/catalogs.py
+++ b/pipeline/projects/provenance/catalogs.py
@@ -94,6 +94,7 @@ class AddPhysicalCatalogOwners(Configurable):
 
 class PopulateAuctionCatalog(Configurable):
 	'''Add modeling data for an auction catalog'''
+	helper = Option(required=True)
 	static_instances = Option(default="static_instances")
 
 	def lugt_number_id(self, content):
@@ -103,13 +104,6 @@ class PopulateAuctionCatalog(Configurable):
 		assignment.carried_out_by = self.static_instances.get_instance('Person', 'lugt')
 		lugt_id.assigned_by = assignment
 		return lugt_id
-
-	def gri_number_id(self, content):
-		catalog_id = vocab.LocalNumber(ident='', content=content)
-		assignment = model.AttributeAssignment(ident='')
-		assignment.carried_out_by = self.static_instances.get_instance('Group', 'gri')
-		catalog_id.assigned_by = assignment
-		return catalog_id
 
 	def __call__(self, data):
 		d = {k: v for k, v in data.items()}
@@ -124,7 +118,8 @@ class PopulateAuctionCatalog(Configurable):
 
 		if not cno:
 			warnings.warn(f'Setting empty identifier on {catalog.id}')
-		catalog.identified_by = self.gri_number_id(cno)
+		
+		catalog.identified_by = self.helper.gri_number_id(cno)
 
 		if not sno:
 			warnings.warn(f'Setting empty identifier on {catalog.id}')

--- a/pipeline/projects/provenance/objects.py
+++ b/pipeline/projects/provenance/objects.py
@@ -107,9 +107,13 @@ class PopulateObject(Configurable):
 
 		record_uri = self.helper.make_proj_uri('CATALOG', cno, 'RECORD', rec_num)
 		lot_object_id = parent['lot_object_id']
+		
+		puid = parent.get('persistent_puid')
+		puid_id = self.helper.gri_number_id(puid)
+
 		record = vocab.ParagraphText(ident=record_uri, label=f'Sale recorded in catalog: {lot_object_id} (record number {rec_num})')
 		record_data	= {'uri': record_uri}
-		record_data['identifiers'] = [model.Name(ident='', content=f'Record of sale {lot_object_id}')]
+		record_data['identifiers'] = [model.Name(ident='', content=f'Record of sale {lot_object_id}'), puid_id]
 		record.part_of = catalog
 
 		if parent.get('transaction'):


### PR DESCRIPTION
This required refactoring the existing code to create GRI-assigned `Identifier` values so that it could be used for both catalogs and sales records.