### PR TITLE
Model custody transfers

### DIFF
--- a/pipeline/projects/provenance/__init__.py
+++ b/pipeline/projects/provenance/__init__.py
@@ -180,7 +180,6 @@ class PersonIdentity:
 			dated_match = self.anon_dated_re.match(auth_name)
 			if dated_match:
 				with suppress(ValueError):
-					print(dated_match.group(1))
 					century = int(dated_match.group(1))
 					ord = make_ordinal(century)
 					data['label'] = f'anonymous {role}s of the {ord} century'
@@ -194,7 +193,6 @@ class PersonIdentity:
 			if period_match:
 				period = period_match.group(1).lower()
 				data['label'] = f'anonymous {period} {role}s'
-				print(data['label'])
 
 	def add_names(self, data:dict, referrer=None, role=None):
 		'''

--- a/pipeline/projects/provenance/__init__.py
+++ b/pipeline/projects/provenance/__init__.py
@@ -526,6 +526,10 @@ class ProvenancePipeline(PipelineBase):
 		helper = ProvenanceUtilityHelper(project_name)
 		self.uid_tag_prefix = UID_TAG_PREFIX
 
+		vocab.register_instance('act of selling', {'parent': model.Activity, 'id': 'XXXXXX001', 'label': 'Act of Selling'})
+		vocab.register_instance('act of returning', {'parent': model.Activity, 'id': 'XXXXXX002', 'label': 'Act of Returning'})
+		vocab.register_instance('act of completing sale', {'parent': model.Activity, 'id': 'XXXXXX003', 'label': 'Act of Completing Sale'})
+
 		vocab.register_instance('fire', {'parent': model.Type, 'id': '300068986', 'label': 'Fire'})
 		vocab.register_instance('animal', {'parent': model.Type, 'id': '300249395', 'label': 'Animal'})
 		vocab.register_instance('history', {'parent': model.Type, 'id': '300033898', 'label': 'History'})

--- a/pipeline/projects/provenance/events.py
+++ b/pipeline/projects/provenance/events.py
@@ -126,7 +126,6 @@ class AddAuctionHouses(Configurable):
 			self.helper.add_auction_house_data(self.helper.copy_source_information(h, data), sequence=i, event_record=event_record)
 			house = get_crom_object(h)
 			auction.carried_out_by = house
-			if auction_houses:
-				house_objects.append(house)
+			house_objects.append(house)
 		auction_houses[cno] = house_objects
 		return d

--- a/pipeline/projects/provenance/lots.py
+++ b/pipeline/projects/provenance/lots.py
@@ -729,7 +729,6 @@ class AddAcquisitionOrBidding(Configurable):
 					houses = [add_crom_data(data={}, what=h) for h in auction_houses.get(cno, [])]
 					for i, h in enumerate(houses):
 						house = get_crom_object(h)
-						print(f'sold auction house: {h}')
 						if hasattr(house, 'label'):
 							house._label = f'{house._label}, private sale organizer for {cno} {shared_lot_number} ({date})'
 						else:

--- a/pipeline/projects/provenance/lots.py
+++ b/pipeline/projects/provenance/lots.py
@@ -216,11 +216,14 @@ class AddAcquisitionOrBidding(Configurable):
 	auction_houses = Service('auction_houses')
 	buy_sell_modifiers = Service('buy_sell_modifiers')
 	transaction_types = Service('transaction_types')
-	custody_xfer_purposes = {
-		'to sell': model.Activity(ident='http://vocab.getty.edu/aat/XXX_1', label='Act of Selling'),
-		'returning': model.Activity(ident='http://vocab.getty.edu/aat/XXX_2', label='Act of Returning'),
-		'completing sale': model.Activity(ident='http://vocab.getty.edu/aat/XXX_3', label='Act of Completing Sale'),
-	}
+
+	def __init__(self, *args, **kwargs):
+		self.custody_xfer_purposes = {
+			'to sell': vocab.instances['act of selling'],
+			'returning': vocab.instances['act of returning'],
+			'completing sale': vocab.instances['act of completing sale'],
+		}
+		super().__init__(*args, **kwargs)
 
 	@staticmethod
 	def related_procurement(hmo, tx_label_args, current_tx=None, current_ts=None, buyer=None, seller=None, previous=False, ident=None):

--- a/pipeline/projects/provenance/lots.py
+++ b/pipeline/projects/provenance/lots.py
@@ -180,21 +180,21 @@ class AddAuctionOfLot(Configurable):
 			self.set_lot_date(lot, auction_data)
 			self.set_lot_notes(lot, auction_data, sale_type)
 
-			if transaction in SOLD:
-				# only model a ProvenanceEntry caused by this Auction of Lot if the transaction type is sold
-				tx_uri = self.helper.transaction_uri_for_lot(auction_data, data)
-				lots = self.helper.lots_in_transaction(auction_data, data)
-				multi = self.helper.transaction_contains_multiple_lots(auction_data, data)
-				tx = vocab.ProvenanceEntry(ident=tx_uri)
-				tx._label = prov_entry_label(sale_type, transaction, transaction_types, cno, lots, date, 'of')
-				lot.caused = tx
-				tx_data = {'uri': tx_uri}
+			tx_uri = self.helper.transaction_uri_for_lot(auction_data, data)
+			lots = self.helper.lots_in_transaction(auction_data, data)
+			tx = vocab.ProvenanceEntry(ident=tx_uri)
+			tx._label = prov_entry_label(sale_type, transaction, transaction_types, cno, lots, date, 'of')
+			lot.caused = tx
+			tx_data = {'uri': tx_uri}
 
+			if transaction in SOLD:
+				multi = self.helper.transaction_contains_multiple_lots(auction_data, data)
 				if multi:
 					tx_data['multi_lot_tx'] = lots
-				with suppress(AttributeError):
-					tx_data['_date'] = lot.timespan
-				data['_prov_entry_data'] = add_crom_data(data=tx_data, what=tx)
+
+			with suppress(AttributeError):
+				tx_data['_date'] = lot.timespan
+			data['_prov_entry_data'] = add_crom_data(data=tx_data, what=tx)
 
 			data['_event_causing_prov_entry'] = add_crom_data(data=sale_data, what=lot)
 		yield data
@@ -213,8 +213,14 @@ def prov_entry_label(sale_type, transaction, transaction_types, cno, lots, date,
 class AddAcquisitionOrBidding(Configurable):
 	helper = Option(required=True)
 	non_auctions = Service('non_auctions')
+	auction_houses = Service('auction_houses')
 	buy_sell_modifiers = Service('buy_sell_modifiers')
 	transaction_types = Service('transaction_types')
+	custody_xfer_purposes = {
+		'to sell': model.Activity(ident='http://vocab.getty.edu/aat/XXX_1', label='Act of Selling'),
+		'returning': model.Activity(ident='http://vocab.getty.edu/aat/XXX_2', label='Act of Returning'),
+		'completing sale': model.Activity(ident='http://vocab.getty.edu/aat/XXX_3', label='Act of Completing Sale'),
+	}
 
 	@staticmethod
 	def related_procurement(hmo, tx_label_args, current_tx=None, current_ts=None, buyer=None, seller=None, previous=False, ident=None):
@@ -303,7 +309,9 @@ class AddAcquisitionOrBidding(Configurable):
 		tx = self.related_procurement(hmo, tx_label_args, current_tx, current_ts, buyer=final_owner, ident=tx_uri)
 		return tx
 
-	def add_transfer_of_custody(self, data, current_tx, buyers, sellers, non_auctions, buy_sell_modifiers, sequence=1):
+	def add_transfer_of_custody(self, data, current_tx, xfer_to, xfer_from, sequence=1, purpose=None):
+		buyers = xfer_to
+		sellers = xfer_from
 		hmo = get_crom_object(data)
 		parent = data['parent_data']
 		auction_data = parent['auction_of_lot']
@@ -317,14 +325,15 @@ class AddAcquisitionOrBidding(Configurable):
 			object_label = '(object)'
 			xfer_label = f'Transfer of Custody for {cno} {lno} ({date})'
 
+		# TODO: pass in the tx to use instead of getting it from `parent`
 		tx_data = parent['_prov_entry_data']
 		current_tx = get_crom_object(tx_data)
 
 		xfer_id = hmo.id + f'-CustodyTransfer-{sequence}'
 		xfer = model.TransferOfCustody(ident=xfer_id, label=xfer_label)
 		xfer.transferred_custody_of = hmo
-
-		THROUGH = set(buy_sell_modifiers['through'])
+		if purpose in self.custody_xfer_purposes:
+			xfer.specific_purpose = self.custody_xfer_purposes[purpose]
 
 		for seller_data in sellers:
 			seller = get_crom_object(seller_data)
@@ -567,7 +576,7 @@ class AddAcquisitionOrBidding(Configurable):
 		rel = 'leading to the previous ownership of'
 		return self.add_sellers(data, sale_type, transaction, transaction_types, sellers, rel, source=note)
 
-	def add_bidding(self, data:dict, buyers, sellers, buy_sell_modifiers, sale_type, transaction, transaction_types):
+	def add_bidding(self, data:dict, buyers, sellers, buy_sell_modifiers, sale_type, transaction, transaction_types, auction_houses):
 		'''Add modeling of bids that did not lead to an acquisition'''
 		hmo = get_crom_object(data)
 		parent = data['parent_data']
@@ -583,12 +592,26 @@ class AddAcquisitionOrBidding(Configurable):
 			return
 		ts = lot.timespan
 
+		UNSOLD = CaseFoldingSet(transaction_types['unsold'])
+		model_custody_return = transaction in UNSOLD
 		prev_procurements = self.add_non_sale_sellers(data, sellers, sale_type, transaction, transaction_types)
 
 		prices = parent.get('price', [])
 		if not prices:
 			yield data
 		amnts = [get_crom_object(p) for p in prices]
+
+		tx_data = parent.get('_prov_entry_data')
+		tx = get_crom_object(tx_data)
+		houses = [add_crom_data(data={}, what=h) for h in auction_houses.get(cno, [])]
+		self.add_transfer_of_custody(data, tx, xfer_to=houses, xfer_from=sellers, sequence=1, purpose='to sell')
+		if model_custody_return:
+			print(f'*** transfer of custody back to seller: {tx.id} ; {tx._label}')
+			self.add_transfer_of_custody(data, tx, xfer_to=sellers, xfer_from=houses, sequence=2, purpose='returning')
+
+		if '_procurements' not in data:
+			data['_procurements'] = []
+		data['_procurements'].append(tx_data)
 
 		if amnts:
 			bidding_id = hmo.id + '-Bidding'
@@ -638,8 +661,6 @@ class AddAcquisitionOrBidding(Configurable):
 				hmo = get_crom_object(data)
 				tx_label_args = tuple([sale_type, 'Sold', transaction_types] + list(lot_object_key) + ['leading to the currently known location of'])
 				tx = self.final_owner_procurement(tx_label_args, final_owner, None, hmo, ts)
-				if '_procurements' not in data:
-					data['_procurements'] = []
 				data['_procurements'].append(add_crom_data(data={}, what=tx))
 
 			data['_bidding'] = {'uri': bidding_id}
@@ -660,7 +681,7 @@ class AddAcquisitionOrBidding(Configurable):
 		pi.add_person(data, sales_record, relative_id=rec_id)
 		return data
 
-	def __call__(self, data:dict, non_auctions, buy_sell_modifiers, transaction_types):
+	def __call__(self, data:dict, non_auctions, auction_houses, buy_sell_modifiers, transaction_types):
 		'''Determine if this record has an acquisition or bidding, and add appropriate modeling'''
 		parent = data['parent_data']
 		sales_record = get_crom_object(data['_record'])
@@ -698,34 +719,34 @@ class AddAcquisitionOrBidding(Configurable):
 			
 			for data, current_tx in self.add_acquisition(data, buyers, sellers, non_auctions, buy_sell_modifiers, transaction, transaction_types):
 				if sale_type == 'Auction':
-					self.add_transfer_of_custody(data, current_tx, buyers, sellers, non_auctions, buy_sell_modifiers)
+					self.add_transfer_of_custody(data, current_tx, xfer_to=buyers, xfer_from=sellers, purpose='to sell')
 				elif sale_type in ('Private Contract Sale', 'Stock List'):
 					# 'Stock List' is treated just like a Private Contract Sale, except for the catalogs
 					metadata = {
 						'pi_record_no': parent['pi_record_no'],
 						'catalog_number': cno
 					}
-					houses = parent.get('auction_house', [])
+					houses = [add_crom_data(data={}, what=h) for h in auction_houses.get(cno, [])]
 					for i, h in enumerate(houses):
-						self.helper.add_auction_house_data(self.helper.copy_source_information(h, metadata), sequence=i, event_record=sales_record)
 						house = get_crom_object(h)
+						print(f'sold auction house: {h}')
 						if hasattr(house, 'label'):
 							house._label = f'{house._label}, private sale organizer for {cno} {shared_lot_number} ({date})'
 						else:
 							house._label = f'Private sale organizer for {cno} {shared_lot_number} ({date})'
 
-						self.add_transfer_of_custody(data, current_tx, [h], sellers, non_auctions, buy_sell_modifiers, sequence=1)
-						self.add_transfer_of_custody(data, current_tx, buyers, [h], non_auctions, buy_sell_modifiers, sequence=2)
+						self.add_transfer_of_custody(data, current_tx, xfer_to=[h], xfer_from=sellers, sequence=1, purpose='to sell')
+						self.add_transfer_of_custody(data, current_tx, xfer_to=buyers, xfer_from=[h], sequence=2, purpose='completing sale')
 						data['_organizations'].append(h)
 					prev_procurements = self.add_private_sellers(data, sellers, sale_type, transaction, transaction_types)
 				yield data
 		elif transaction in UNSOLD:
-			yield from self.add_bidding(data, buyers, sellers, buy_sell_modifiers, sale_type, transaction, transaction_types)
+			yield from self.add_bidding(data, buyers, sellers, buy_sell_modifiers, sale_type, transaction, transaction_types, auction_houses)
 		elif transaction in UNKNOWN:
 			if sale_type == 'Lottery':
 				yield data
 			else:
-				yield from self.add_bidding(data, buyers, sellers, buy_sell_modifiers, sale_type, transaction, transaction_types)
+				yield from self.add_bidding(data, buyers, sellers, buy_sell_modifiers, sale_type, transaction, transaction_types, auction_houses)
 		else:
 			prev_procurements = self.add_non_sale_sellers(data, sellers, sale_type, transaction, transaction_types)
 			lot = get_crom_object(parent['_event_causing_prov_entry'])

--- a/tests/test_pir_modeling_attrib_mod.py
+++ b/tests/test_pir_modeling_attrib_mod.py
@@ -60,12 +60,13 @@ class PIRModelingTest_AttributionModifiers(TestProvenancePipelineOutput):
 		#   "Dr. S. (Berlin W 15, Kaiserallee 208)" (seller of an unsold transaction ("Unverkauft"))
 		self.assertEqual(len(people), 16)
 
-		# there are 4 groups:
+		# there are 5 groups:
 		# 	'FollowerGroup of artist “RUBENS, PETER PAUL”' (influencer of the formation of the "follower of" group)
 		# 	'School of artist “RUBENS, PETER PAUL”' (influencer of the formation of the "school of" group)
 		# 	'Workshop of artist “WEST, BENJAMIN”' (influencer of the formation of the "workshop of" group)
 		# 	'Circle of artist “POUSSIN, NICOLAS”' (influencer of the formation of the "circle of" group)
-		self.assertEqual(len(groups), 4)
+		# 	GRI (used as the assigner of a LocalNumber)
+		self.assertEqual(len(groups), 5)
 		
 		# 'style of' modifiers use an AttributeAssignment that classifies the 'influenced_by' property as being 'Style of'
 		style_of_obj = objects['tag:getty.edu,2019:digital:pipeline:REPLACE-WITH-UUID:provenance#OBJ,Br-A2493,0029%5Bb%5D,1800-03-01']

--- a/tests/test_pir_modeling_private_contract.py
+++ b/tests/test_pir_modeling_private_contract.py
@@ -110,7 +110,7 @@ class PIRModelingTest_PrivateContractSales(TestProvenancePipelineOutput):
 		# seller   : Havre, Jean-Michel-Antoine-Joseph-Louis, baron van		500439105
 		# buyer    : Stier d'Aertselaer, Henri-Joseph, baron				500440144
 		# organizer: Anonymous												22949
-		event_organizer = 'tag:getty.edu,2019:digital:pipeline:REPLACE-WITH-UUID:provenance#HOUSE,PI,22949,0' # TODO this should be pulled from the data
+		event_organizer = 'tag:getty.edu,2019:digital:pipeline:REPLACE-WITH-UUID:provenance#HOUSE,STAR,226,0' # TODO this should be pulled from the data
 
 		buyers = acq['transferred_title_to']
 		self.assertEqual(len(buyers), 1)

--- a/tests/test_pir_pipeline.py
+++ b/tests/test_pir_pipeline.py
@@ -90,7 +90,7 @@ class TestProvenancePipelineOutput(unittest.TestCase):
 		self.assertEqual(len(people), 4, 'expected count of people') # 3 from the data, and 1 (Lugt) which is a static instance
 		self.assertEqual(len(objects), 6, 'expected count of physical objects')
 		self.assertEqual(len(los), 4, 'expected count of linguistic objects')
-		self.assertEqual(len(activities), 1, 'expected count of activities')
+		self.assertEqual(len(activities), 3, 'expected count of activities') # 1 auction event and 2 prov entries
 		self.assertEqual(len(auctions), 2, 'expected count of auctions of lot')
 		self.assertEqual(len(houses), 1, 'expected count of auction houses')
 
@@ -121,7 +121,7 @@ class TestProvenancePipelineOutput(unittest.TestCase):
 		events = [activities[k] for k in activities if k not in {key_119, key_120}]
 		event_labels = {e['_label'] for e in events}
 		carried_out_by = {h['id'] for e in events for h in e.get('carried_out_by', [])}
-		self.assertEqual(event_labels, {'Auction Event for B-A139'})
+		self.assertEqual(event_labels, {'Auction Event for B-A139', 'Offer of B-A139 0119 (1774-05-31)', 'Offer of B-A139 0120 (1774-05-31)'})
 		self.assertEqual(carried_out_by, house_ids)
 
 


### PR DESCRIPTION
This adds modeling of custody transfers for non-sale records:

* unsold records: custody transfers to the auction house and then back to the seller)
* unknown records: custody transfers to the auction house

Transfer of custody activities are classified as to their purpose (to be sold, to be returned, and for the completion of a sale).

Also included are fixes existing problems with the related modeling of transfer of custody for sold records.

This code includes custom crom instances that do not yet have proper AAT codes. This will need to be updated in the future.