### PR TITLE
Reduce unnecessary calls to CaseFoldingSet and casefold.

### DIFF
--- a/pipeline/projects/__init__.py
+++ b/pipeline/projects/__init__.py
@@ -45,8 +45,9 @@ class StaticInstanceHolder:
 		return used
 
 class PipelineBase:
-	def __init__(self, project_name, *, helper):
+	def __init__(self, project_name, *, helper, parallel=False):
 		self.project_name = project_name
+		self.parallel = parallel
 		self.helper = helper
 		self.static_instances = StaticInstanceHolder(self.setup_static_instances())
 		self.services = self.setup_services()
@@ -139,7 +140,7 @@ class PipelineBase:
 			sys.stderr.write('*** No serialization chain defined\n')
 
 	def run_graph(self, graph, *, services):
-		if False:
+		if self.parallel:
 			print('Running with PARALLEL bonobo executor')
 			bonobo.run(graph, services=services)
 		else:
@@ -164,6 +165,7 @@ class UtilityHelper:
 		constructor instead.
 		'''
 		self.services = services
+		self.unique_locations = CaseFoldingSet(self.services.get('unique_locations', {}).get('place_names', []))
 
 	def add_static_instances(self, static_instances):
 		self.static_instances = static_instances
@@ -200,7 +202,7 @@ class UtilityHelper:
 		- type (one of: 'City', 'State', 'Province', or 'Country')
 		- part_of (a recursive place dictionary)
 		'''
-		unique_locations = CaseFoldingSet(self.services.get('unique_locations', {}).get('place_names', []))
+		unique_locations = self.unique_locations
 		TYPES = {
 			'city': vocab.instances['city'],
 			'province': vocab.instances['province'],

--- a/pipeline/projects/sales/__init__.py
+++ b/pipeline/projects/sales/__init__.py
@@ -712,6 +712,14 @@ class SalesPipeline(PipelineBase):
 	# Set up environment
 		'''Return a `dict` of named services available to the bonobo pipeline.'''
 		services = super().setup_services()
+		for name in ('transaction_types', 'attribution_modifiers'):
+			services[name] = {k: CaseFoldingSet(v) for k, v in services[name].items()}
+
+		attribution_modifiers = services['attribution_modifiers']
+		PROBABLY = attribution_modifiers['probably by']
+		POSSIBLY = attribution_modifiers['possibly by']
+		attribution_modifiers['uncertain'] = PROBABLY | POSSIBLY
+
 		services.update({
 			# to avoid constructing new MakeLinkedArtPerson objects millions of times, this
 			# is passed around as a service to the functions and classes that require it.

--- a/pipeline/projects/sales/lots.py
+++ b/pipeline/projects/sales/lots.py
@@ -190,7 +190,7 @@ class AddAuctionOfLot(Configurable):
 			lot.referred_to_by = cite
 
 		transaction = data.get('transaction')
-		SOLD = CaseFoldingSet(transaction_types['sold'])
+		SOLD = transaction_types['sold']
 		WITHDRAWN = transaction_types['withdrawn']
 		self.set_lot_objects(lot, cno, lno, sale_data['uri'], data, sale_type)
 		auction, _, _ = self.helper.sale_event_for_catalog_number(cno, sale_type)
@@ -228,7 +228,7 @@ class AddAuctionOfLot(Configurable):
 		yield data
 	
 def prov_entry_label(sale_type, transaction, transaction_types, cno, lots, date, rel):
-	SOLD = CaseFoldingSet(transaction_types['sold'])
+	SOLD = transaction_types['sold']
 	id = f'{cno} {lots} ({date})'
 	if sale_type == 'Auction':
 		if transaction in SOLD:
@@ -648,7 +648,7 @@ class AddAcquisitionOrBidding(Configurable):
 			return
 		ts = lot.timespan
 
-		UNSOLD = CaseFoldingSet(transaction_types['unsold'])
+		UNSOLD = transaction_types['unsold']
 		model_custody_return = transaction in UNSOLD
 		prev_procurements = self.add_non_sale_sellers(data, sellers, sale_type, transaction, transaction_types)
 
@@ -768,10 +768,10 @@ class AddAcquisitionOrBidding(Configurable):
 			) for i, p in enumerate(parent['seller'])
 		]
 
-		SOLD = CaseFoldingSet(transaction_types['sold'])
-		UNSOLD = CaseFoldingSet(transaction_types['unsold'])
-		UNKNOWN = CaseFoldingSet(transaction_types['unknown'])
-		
+		SOLD = transaction_types['sold']
+		UNSOLD = transaction_types['unsold']
+		UNKNOWN = transaction_types['unknown']
+
 		if '_procurements' not in data:
 			data['_procurements'] = []
 

--- a/pipeline/projects/sales/lots.py
+++ b/pipeline/projects/sales/lots.py
@@ -13,8 +13,7 @@ from pipeline.util import \
 		implode_date, \
 		timespan_from_outer_bounds, \
 		timespan_before, \
-		timespan_after, \
-		CaseFoldingSet
+		timespan_after
 from pipeline.util.cleaners import parse_location_name
 import pipeline.linkedart
 from pipeline.linkedart import add_crom_data, get_crom_object

--- a/pipeline/util/__init__.py
+++ b/pipeline/util/__init__.py
@@ -564,16 +564,15 @@ class CaseFoldingSet(set):
 	def __init__(self, iterable):
 		super().__init__(self)
 		for v in iterable:
-			if isinstance(v, str):
-				self.add(v.casefold())
-			else:
-				self.add(v)
+			self.add(v)
 
 	def __and__(self, value):
 		return CaseFoldingSet({s for s in value if s in self})
 
 	def __or__(self, value):
-		s = CaseFoldingSet(self)
+		s = CaseFoldingSet({})
+		for v in self:
+			super().add(v)
 		for v in value:
 			s.add(v)
 		return s
@@ -586,6 +585,17 @@ class CaseFoldingSet(set):
 
 	def __contains__(self, v):
 		return super().__contains__(v.casefold())
+
+	def intersects(self, values):
+		if isinstance(values, CaseFoldingSet):
+			l = set(self)
+			r = set(values)
+			return l & r
+		else:
+			for v in values:
+				if v in self:
+					return True
+			return False
 
 def truncate_with_ellipsis(s, length=100):
 	'''

--- a/sales.py
+++ b/sales.py
@@ -26,10 +26,12 @@ if __name__ == '__main__':
 	contents = {
 		'header_file': 'sales_contents_0.csv',
 		'files_pattern': 'sales_contents_[!0]*.csv',
+# 		'files_pattern': 'sales_contents_A.csv',
 	}
 	auction_events = {
 		'header_file': 'sales_descriptions_0.csv',
 		'files_pattern': 'sales_descriptions.csv',
+# 		'files_pattern': 'sales_descriptions_A.csv',
 	}
 
 #	factory.production_mode()


### PR DESCRIPTION
Pre-construct the `CaseFoldingSet` objects so that they are not re-initialized on every input record.