### PR TITLE
Fix CromObjectMerger to work with brief texts as metatypes

### DIFF
--- a/pipeline/projects/sales/lots.py
+++ b/pipeline/projects/sales/lots.py
@@ -438,7 +438,7 @@ class AddAcquisitionOrBidding(Configurable):
 		single_seller = (len(sellers) == 1)
 		single_buyer = (len(buyers) == 1)
 
-		for seller_data in sellers:
+		for seq_no, seller_data in enumerate(sellers):
 			seller = get_crom_object(seller_data)
 			mod = seller_data.get('auth_mod_a', '')
 
@@ -455,12 +455,12 @@ class AddAcquisitionOrBidding(Configurable):
 				acq.transferred_title_from = seller
 				paym.paid_to = seller
 			elif mod == 'or anonymous':
-				acq_assignment = vocab.PossibleAssignment(ident='', label=f'Uncertain seller as previous title holder in acquisition')
+				acq_assignment = vocab.PossibleAssignment(ident=acq.id + f'-seller-assignment-{seq_no}', label=f'Uncertain seller as previous title holder in acquisition')
 				acq_assignment.assigned_property = 'transferred_title_from'
 				acq_assignment.assigned = seller
 				acq.attributed_by = acq_assignment
 
-				paym_assignment = vocab.PossibleAssignment(ident='', label=f'Uncertain seller as recipient of payment')
+				paym_assignment = vocab.PossibleAssignment(ident=paym.id + f'-seller-assignment-{seq_no}', label=f'Uncertain seller as recipient of payment')
 				paym_assignment.assigned_property = 'paid_to'
 				paym_assignment.assigned = seller
 				paym.attributed_by = paym_assignment

--- a/pipeline/projects/sales/objects.py
+++ b/pipeline/projects/sales/objects.py
@@ -389,6 +389,7 @@ class AddArtists(Configurable):
 		or_anon_records = [is_or_anon(a) for a in artists]
 		uncertain_attribution = any(or_anon_records)
 		for seq_no, a in enumerate(artists):
+			attribute_assignment_id = event.id + f'-artist-assignment-{seq_no}'
 			if is_or_anon(a):
 				# do not model the "or anonymous" records; they turn into uncertainty on the other records
 				continue
@@ -422,7 +423,7 @@ class AddArtists(Configurable):
 					# equivalent to no modifier
 					pass
 				elif STYLE_OF.intersects(mods):
-					assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'In the style of {artist_label}')
+					assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident=attribute_assignment_id, label=f'In the style of {artist_label}')
 					event.attributed_by = assignment
 					assignment.assigned_property = 'influenced_by'
 					assignment.property_classified_as = vocab.instances['style of']
@@ -446,7 +447,7 @@ class AddArtists(Configurable):
 					subevent.carried_out_by = group
 
 					if uncertain_attribution:
-						assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'Possibly attributed to {group_label}')
+						assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident=attribute_assignment_id, label=f'Possibly attributed to {group_label}')
 						event.attributed_by = assignment
 						assignment.assigned_property = 'part'
 						assignment.assigned = subevent
@@ -456,7 +457,7 @@ class AddArtists(Configurable):
 				elif FORMERLY_ATTRIBUTED_TO.intersects(mods):
 					# the {uncertain_attribution} flag does not apply to this branch, because this branch is not making a statement
 					# about a previous attribution. the uncertainty applies only to the current attribution.
-					assignment = vocab.ObsoleteAssignment(ident='', label=f'Formerly attributed to {artist_label}')
+					assignment = vocab.ObsoleteAssignment(ident=attribute_assignment_id, label=f'Formerly attributed to {artist_label}')
 					event.attributed_by = assignment
 					assignment.assigned_property = 'carried_out_by'
 					assignment.assigned = person
@@ -464,11 +465,11 @@ class AddArtists(Configurable):
 				elif UNCERTAIN.intersects(mods):
 					if POSSIBLY.intersects(mods):
 						attrib_assignment_classes.append(vocab.PossibleAssignment)
-						assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'Possibly attributed to {artist_label}')
+						assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident=attribute_assignment_id, label=f'Possibly attributed to {artist_label}')
 						assignment._label = f'Possibly by {artist_label}'
 					else:
 						attrib_assignment_classes.append(vocab.ProbableAssignment)
-						assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'Probably attributed to {artist_label}')
+						assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident=attribute_assignment_id, label=f'Probably attributed to {artist_label}')
 						assignment._label = f'Probably by {artist_label}'
 					event.attributed_by = assignment
 					assignment.assigned_property = 'carried_out_by'
@@ -505,7 +506,7 @@ class AddArtists(Configurable):
 			subevent = model.Production(ident=subevent_id, label=f'Production sub-event for {artist_label}')
 			subevent.carried_out_by = person
 			if uncertain_attribution or 'or' in mods:
-				assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident='', label=f'Possibly attributed to {artist_label}')
+				assignment = vocab.make_multitype_obj(*attrib_assignment_classes, ident=attribute_assignment_id, label=f'Possibly attributed to {artist_label}')
 				event.attributed_by = assignment
 				assignment.assigned_property = 'part'
 				assignment.assigned = subevent

--- a/tests/test_merge_brief_texts.py
+++ b/tests/test_merge_brief_texts.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3 -B
+import unittest
+import os
+import os.path
+import hashlib
+import json
+import uuid
+import pprint
+
+from cromulent import model, vocab
+from cromulent.model import factory
+from pipeline.util import CromObjectMerger
+
+class TestMergedBriefTexts(unittest.TestCase):
+	def setUp(self):
+		pass
+
+	def tearDown(self):
+		pass
+
+	def person(self, label):
+		p = model.Person(ident='http://example.org/person', label=label)
+		p.referred_to_by = vocab.Note(ident='', content='This is Eve')
+		return p
+
+	def test_merge(self):
+		p1 = self.person('Eve 1')
+		p2 = self.person('Eve 2')
+
+		merger = CromObjectMerger()
+		merger.merge(p1, p2)
+
+		referrers = p1.referred_to_by
+		self.assertEqual(len(referrers), 1)
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
Also add a few URI-assignments in the modeling to help improve merging.