### PR TITLE
Add handling for people authority display names.

### DIFF
--- a/pipeline/projects/__init__.py
+++ b/pipeline/projects/__init__.py
@@ -332,16 +332,25 @@ class PersonIdentity:
 		If the `role` string is given (e.g. 'artist'), also sets the `role_label` key
 		to a value (e.g. 'artist “RUBENS, PETER PAUL”').
 		'''
+		data.setdefault('identifiers', [])
 		auth_name = data.get('auth_name', '')
+		disp_name = data.get('auth_display_name')
+		name_type = vocab.PrimaryName
+		
+		if disp_name:
+			data['identifiers'].append(vocab.Name(ident='', content=auth_name))
+			auth_name = disp_name
+			name_type = vocab.Name
+
 		role_label = None
 		if self.acceptable_person_auth_name(auth_name):
 			if role:
 				role_label = f'{role} “{auth_name}”'
 			data['label'] = auth_name
-			pname = vocab.PrimaryName(ident='', content=auth_name) # NOTE: most of these are also vocab.SortName, but not 100%, so witholding that assertion for now
+			pname = name_type(ident='', content=auth_name) # NOTE: most of these are also vocab.SortName, but not 100%, so witholding that assertion for now
 			if referrer:
 				pname.referred_to_by = referrer
-			data['identifiers'] = [pname]
+			data['identifiers'].append(pname)
 
 		if 'names' not in data:
 			data['names'] = []

--- a/pipeline/projects/people.py
+++ b/pipeline/projects/people.py
@@ -186,6 +186,7 @@ class AddPerson(Configurable):
 		data.setdefault('events', [])
 		data.setdefault('places', [])
 		data.setdefault('contact_point', [])
+		data.setdefault('identifiers', [])
 
 		self.handle_dates(data)
 		self.handle_statements(data)
@@ -245,6 +246,7 @@ class PeoplePipeline(PipelineBase):
 							'person': {
 								'rename_keys': {
 									'person_authority': 'auth_name',
+									'person_auth_disp': 'auth_display_name',
 									'ulan_id': 'ulan',
 									'birth_date': 'birth',
 									'death_date': 'death',
@@ -253,6 +255,7 @@ class PeoplePipeline(PipelineBase):
 								'properties': (
 									'star_record_no',
 									'person_authority',
+									'person_auth_disp',
 									'variant_names',
 									'type',
 									'project',


### PR DESCRIPTION
I believe this aligns with our discussions with GRI regarding the display names:

For some `Group` records, the authority name includes a location (for example, `"Los Angeles, CA, USA.  J. Paul Getty Museum"`). This will be asserted as a `vocab.Name`, but *not* as a `vocab.PrimaryName`. Instead, the _display name_ (`"J. Paul Getty Museum"`) will be asserted as a secondary `vocab.Name`.