### PR TITLE
Remove reference to non-existent star_rec_no_N fields

### DIFF
--- a/pipeline/projects/sales/__init__.py
+++ b/pipeline/projects/sales/__init__.py
@@ -697,7 +697,7 @@ class SalesPipeline(PipelineBase):
 								'prefixes': (
 									'artist_name', 'art_authority',
 									'artist_info', 'nationality', 'artist_ulan',
-									'attrib_mod', 'attrib_mod_auth', 'star_rec_no',
+									'attrib_mod', 'attrib_mod_auth',
 								)
 							},
 							'hand_note': {'prefixes': ('hand_note', 'hand_note_so')},


### PR DESCRIPTION
These were recently removed from STAR exports. The dangling references were causing all but the first artist record to be dropped.