### PR TITLE
Prev/post sale merging bugfix

### DIFF
--- a/scripts/find_matching_json_files.swift
+++ b/scripts/find_matching_json_files.swift
@@ -74,9 +74,11 @@ func findKeys(in value: Any, from map: [String:String]) -> String? {
             }
         }
     } else if let s = value as? String {
-        if map_keys.contains(s) {
-            return s
-        }
+    	for mk in map_keys {
+    		if s.hasPrefix(mk) {
+    			return s
+    		}
+    	}
     }
     return nil
 }

--- a/scripts/rewrite_post_sales_uris.py
+++ b/scripts/rewrite_post_sales_uris.py
@@ -13,31 +13,32 @@ from pathlib import Path
 from settings import output_file_path
 from pipeline.util.rewriting import rewrite_output_files, JSONValueRewriter
 
-if len(sys.argv) < 2:
-	cmd = sys.argv[0]
-	print(f'''
-Usage: {cmd} URI_REWRITE_MAP.json
+if __name__ == '__main__':
+	if len(sys.argv) < 2:
+		cmd = sys.argv[0]
+		print(f'''
+	Usage: {cmd} URI_REWRITE_MAP.json
 
-	'''.lstrip())
-	sys.exit(1)
+		'''.lstrip())
+		sys.exit(1)
 
-rewrite_map_filename = sys.argv[1]
+	rewrite_map_filename = sys.argv[1]
 
-kwargs = {}
-if len(sys.argv) > 2:
-	kwargs['files'] = sys.argv[2:]
+	kwargs = {}
+	if len(sys.argv) > 2:
+		kwargs['files'] = sys.argv[2:]
 
-print(f'Rewriting post-sales URIs ...')
-start_time = time.time()
-with open(rewrite_map_filename, 'r') as f:
-	post_sale_rewrite_map = json.load(f)
-# 	print('Post sales rewrite map:')
-# 	pprint.pprint(post_sale_rewrite_map)
-	r = JSONValueRewriter(post_sale_rewrite_map, prefix=True)
-	prefix = os.path.commonprefix(list(post_sale_rewrite_map.keys()))
-	if len(prefix) > 20:
-		kwargs['content_filter_re'] = re.compile(re.escape(prefix))
-	rewrite_output_files(r, parallel=True, concurrency=8, **kwargs)
-cur = time.time()
-elapsed = cur - start_time
-print(f'Done (%.1fs)' % (elapsed,))
+	print(f'Rewriting post-sales URIs ...')
+	start_time = time.time()
+	with open(rewrite_map_filename, 'r') as f:
+		post_sale_rewrite_map = json.load(f)
+	# 	print('Post sales rewrite map:')
+	# 	pprint.pprint(post_sale_rewrite_map)
+		r = JSONValueRewriter(post_sale_rewrite_map, prefix=True)
+		prefix = os.path.commonprefix(list(post_sale_rewrite_map.keys()))
+		if len(prefix) > 20:
+			kwargs['content_filter_re'] = re.compile(re.escape(prefix))
+		rewrite_output_files(r, parallel=True, concurrency=8, **kwargs)
+	cur = time.time()
+	elapsed = cur - start_time
+	print(f'Done (%.1fs)' % (elapsed,))


### PR DESCRIPTION
This fixes a bug that was preventing all data from being processed during prev/post sale record merging. Specifically, the pre-processing step that finds all files for processing based on their containing the URIs to be rewritten was not recognizing files that contained URIs that had a matching *prefix*. This meant that, for example, two objects would be merged, but the original that they were copied after would not be merged, and one of them would be orphaned in the modeled data.