### PR TITLE
Fix race condition on renaming files in parallel during post-processing.

### DIFF
--- a/pipeline/util/rewriting.py
+++ b/pipeline/util/rewriting.py
@@ -42,6 +42,8 @@ def chunks(l, size):
 
 def rewrite_output_files(r, update_filename=False, parallel=False, concurrency=4, path=None, files=None, **kwargs):
 	print(f'Rewriting JSON output files')
+	if update_filename and parallel:
+		raise Exception('rewrite_output_files cannot be called with both "update_filename" and "parallel" arguments')
 	vocab.add_linked_art_boundary_check()
 	vocab.add_attribute_assignment_check()
 	if not files:

--- a/scripts/rewrite_uris_to_uuids_parallel.py
+++ b/scripts/rewrite_uris_to_uuids_parallel.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
 	print(f'Rewriting URIs to UUIDs ...')
 	start_time = time.time()
 	r = UUIDRewriter(prefix, map_file)
-	rewrite_output_files(r, update_filename=True, verify_uuid=True, parallel=True, ignore_errors=True)
+	rewrite_output_files(r, update_filename=True, verify_uuid=True, ignore_errors=True)
 	if map_file:
 		r.persist_map()
 	cur = time.time()


### PR DESCRIPTION
The post-processing step that converts temporary URIs to UUID URNs had a race condition when run in parallel and set to rename files using the resulting UUID.

This manifested in at least one case as a dropping of an artist record in a case where an object appearing in multiple sales had differing artist records.

The trivial fix is to disallow file renaming with parallel processing. This will result in significantly longer post-processing time.