### PR TITLE
[AR-57] Improve handling of before/after dates.

### DIFF
--- a/pipeline/util/__init__.py
+++ b/pipeline/util/__init__.py
@@ -518,7 +518,7 @@ def make_ordinal(n):
 		suffix = 'th'
 	return f'{n}{suffix}'
 
-def timespan_for_century(century, narrow=False, **kwargs):
+def timespan_for_century(century, narrow=False, inclusive=False, **kwargs):
 	'''
 	Given a integer representing a century (e.g. 17 for the 17th century), return a
 	TimeSpan object for the bounds of that century.

--- a/pipeline/util/cleaners.py
+++ b/pipeline/util/cleaners.py
@@ -500,14 +500,14 @@ def date_cleaner(value):
 		except:
 			warnings.warn("Bad aft value: %s" % value)
 			return None
-		return [datetime(y,1,1), None]
+		return [datetime(y,1,1), datetime(y+CIRCA+1,1,1)] # GRI guideline says that 'after 1900' really means (1900 or later)
 
 	elif value.startswith('bef'):
 		value = value.replace('bef.', '')
 		value = value.replace('before ', '')
 		value = value.strip()
 		y = int(value)
-		return [None, datetime(y-1,12,31)]
+		return [datetime(y-CIRCA,1,1), datetime(y+1,1,1)] # GRI guideline says that 'before 1900' really means (up to and including 1900)
 
 	elif len(value) <= 4 and (value.endswith('st') or value.endswith('nd') or value.endswith('rd') or value.endswith('th')):
 		century = value[:len(value)-2]

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -25,12 +25,12 @@ class TestDateCleaners(unittest.TestCase):
 			'04/02/1804': [datetime(1804,2,4), datetime(1804,2,5)],			# DD/MM/YYYY
 			'ca. 1806': [datetime(1801,1,1), datetime(1811,1,1)],			# ca. YYYY
 			'ca.1806': [datetime(1801,1,1), datetime(1811,1,1)],			# ca. YYYY
-			'aft. 1807': [datetime(1807,1,1), None],						# aft[er|.] YYYY
-			'aft.1807': [datetime(1807,1,1), None],							# aft[er|.] YYYY
-			'after 1808': [datetime(1808,1,1), None],						# aft[er|.] YYYY
-			'bef. 1810': [None, datetime(1809,12,31)],						# bef[ore|.] YYYY
-			'bef.1810': [None, datetime(1809,12,31)],						# bef[ore|.] YYYY
-			'before 1811': [None, datetime(1810,12,31)],					# bef[ore|.] YYYY
+			'aft. 1807': [datetime(1807,1,1), datetime(1813,1,1)],			# aft[er|.] YYYY
+			'aft.1807': [datetime(1807,1,1), datetime(1813,1,1)],			# aft[er|.] YYYY
+			'after 1808': [datetime(1808,1,1), datetime(1814,1,1)],			# aft[er|.] YYYY
+			'bef. 1810': [datetime(1805,1,1), datetime(1811,1,1)],			# bef[ore|.] YYYY
+			'bef.1810': [datetime(1805,1,1), datetime(1811,1,1)],			# bef[ore|.] YYYY
+			'before 1811': [datetime(1806,1,1), datetime(1812,1,1)],		# bef[ore|.] YYYY
 			'1812.02.05': [datetime(1812,2,5), datetime(1812,2,6)],			# YYYY.MM.DD
 			'1813/4': [datetime(1813,1,1), datetime(1815,1,1)],				# YYYY/(Y|YY|YYYY)
 			'1814/21': [datetime(1814,1,1), datetime(1822,1,1)],			# YYYY/(Y|YY|YYYY)

--- a/tests/test_people_issue_ar57.py
+++ b/tests/test_people_issue_ar57.py
@@ -42,42 +42,42 @@ class PIRModelingTest_AR57(TestPeoplePipelineOutput):
             '1000': {
                 # only period_active=1910
                 'key': f'{self.PREFIX}AUGLAY%2C%20AUGUSTE',
-                'expected': {('1910-01-01T00:00:00Z', '1911-01-02T00:00:00Z', '1910')},
+                'expected': {('1910-01-01T00:00:00Z', '1911-01-01T00:00:00Z', '1910')},
             },
             '1001': {
                 # period_active=1765 with an irrelevant death_date
                 'key': f'{self.PREFIX}Lebrun%2C%20Pierre',
-                'expected': {('1765-01-01T00:00:00Z', '1766-01-02T00:00:00Z', '1765')},
+                'expected': {('1765-01-01T00:00:00Z', '1766-01-01T00:00:00Z', '1765')},
             },
             '1010': {
                 # period_active=1858-1890 with an irrelevant birth_date
                 'key': f'{self.PREFIX}Escribe%2C%20Eug%C3%A8ne%20Jean%20Louis',
-                'expected': {('1858-01-01T00:00:00Z', '1891-01-02T00:00:00Z', '1858-1890')},
+                'expected': {('1858-01-01T00:00:00Z', '1891-01-01T00:00:00Z', '1858-1890')},
             },
             '1011': {
                 # period_active=18th-19th with birth_date=1743, death_date=1820
                 'key': f'{self.PREFIX}Chandelle%2C%20Andreas%20Joseph',
-                'expected': {('1743-01-01T00:00:00Z', '1821-01-02T00:00:00Z', '18th-19th')},
+                'expected': {('1743-01-01T00:00:00Z', '1821-01-01T00:00:00Z', '18th-19th')},
             },
             '1100': {
                 # period_active=1850 with irrelevant century_active=19th
                 'key': f'{self.PREFIX}CIULI%2C%20GIULIO%20%5BUNIDENTIFIED%5D',
-                'expected': {('1850-01-01T00:00:00Z', '1851-01-02T00:00:00Z', '1850')},
+                'expected': {('1850-01-01T00:00:00Z', '1851-01-01T00:00:00Z', '1850')},
             },
             '1101': {
                 # period_active=bef.1888, century_active=19th-20th, death_date=1938
                 'key': f'{self.PREFIX}D%C3%96RING%2C%20ADOLF%20GUSTAV',
-                'expected': {(None, '1888-01-01T00:00:00Z', 'bef.1888')},
+                'expected': {('1883-01-01T00:00:00Z', '1889-01-01T00:00:00Z', 'bef.1888')},
             },
             '1110': {
                 # period_active=1876, century_active=19th, death_date=1849
                 'key': f'{self.PREFIX}LIECK%2C%20JOSEPH',
-                'expected': {('1876-01-01T00:00:00Z', '1877-01-02T00:00:00Z', '1876')},
+                'expected': {('1876-01-01T00:00:00Z', '1877-01-01T00:00:00Z', '1876')},
             },
             '1111': {
                 # period_active=1945, century_active=20th, birth_date=1907, death_date=1967
                 'key': f'{self.PREFIX}Bilbo%2C%20Jack',
-                'expected': {('1945-01-01T00:00:00Z', '1946-01-02T00:00:00Z', '1945')},
+                'expected': {('1945-01-01T00:00:00Z', '1946-01-01T00:00:00Z', '1945')},
             },
             '0000': {
                 # no date data
@@ -102,22 +102,22 @@ class PIRModelingTest_AR57(TestPeoplePipelineOutput):
             '0100': {
                 # century_active=17th
                 'key': f'{self.PREFIX}BRAIN%20%5BUNIDENTIFIED%5D',
-                'expected': {('1600-01-01T00:00:00Z', '1700-01-02T00:00:00Z', '17th')},
+                'expected': {('1600-01-01T00:00:00Z', '1700-01-01T00:00:00Z', '17th')},
             },
             '0101': {
                 # century_active=18th, death_date=1731
                 'key': f'{self.PREFIX}NIGHTINGALE%2C%20ELIZABETH',
-                'expected': {('1700-01-01T00:00:00Z', '1732-01-02T00:00:00Z', '18th')},
+                'expected': {('1700-01-01T00:00:00Z', '1732-01-01T00:00:00Z', '18th')},
             },
             '0110': {
                 # century_active=19th, birth_date=1844
                 'key': f'{self.PREFIX}FROMENTIN%2C%20JULES',
-                'expected': {('1844-01-01T00:00:00Z', '1900-01-02T00:00:00Z', '19th')},
+                'expected': {('1844-01-01T00:00:00Z', '1900-01-01T00:00:00Z', '19th')},
             },
             '0111': {
                 # century_active=19th, birth_date=1838, death_date=1898
                 'key': f'{self.PREFIX}PAULSEN%2C%20FRITZ',
-                'expected': {('1838-01-01T00:00:00Z', '1899-01-02T00:00:00Z', '19th')},
+                'expected': {('1838-01-01T00:00:00Z', '1899-01-01T00:00:00Z', '19th')},
             },
         }
 


### PR DESCRIPTION
This fixes the interpretation of "bef.YYYY" and "aft.YYYY" dates, as well as fixes a bug in handling professional activity/birth/death dates that left the endpoint of a timespan off by one day.